### PR TITLE
ci: only publish on code changes, add GitHub release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,11 @@ name: Publish to npm
 on:
   push:
     branches: [main]
+    paths:
+      - 'src/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
   workflow_dispatch:
 
 jobs:
@@ -49,7 +54,27 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Get package version
+        id: package
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
       - name: Publish to npm
         run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ steps.package.outputs.version }}
+          name: v${{ steps.package.outputs.version }}
+          body: |
+            ## Installation
+            ```bash
+            npm install -g @swiftlysingh/excalidraw-cli
+            ```
+
+            📦 [View on npm](https://www.npmjs.com/package/@swiftlysingh/excalidraw-cli/v/${{ steps.package.outputs.version }})
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Filter publish workflow to only run on src/**, package.json, etc.
- Create GitHub release with npm link after publishing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enabled automated release creation with version-based tagging and automatic release notes generation for improved release management consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->