### PR TITLE
feat: Support DOT/Graphviz syntax as alternative input format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
-  "name": "excalidraw-cli",
+  "name": "@swiftlysingh/excalidraw-cli",
   "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "excalidraw-cli",
+      "name": "@swiftlysingh/excalidraw-cli",
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",
         "elkjs": "^0.9.3",
-        "nanoid": "^5.0.9"
+        "nanoid": "^5.0.9",
+        "ts-graphviz": "^3.0.6"
       },
       "bin": {
         "excalidraw-cli": "dist/cli.js"
@@ -1017,6 +1018,92 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@ts-graphviz/adapter": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/adapter/-/adapter-3.0.5.tgz",
+      "integrity": "sha512-l6U+jizdkgnwq8Gb4I/Azgr/TGM452ovx2SLxUU/mGZNtrdOol4qi7Gn+d5hP3weBKkUNV9C7j1Xawg4w1DkCw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/common": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ts-graphviz/ast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/ast/-/ast-3.0.5.tgz",
+      "integrity": "sha512-gwrhTWspMU0qIP8V3yLnwUcnV+pJuPRTp5RAzpqYlKcD7NIsMtZfCzN2fzg8SpkJFC5S/9Ajlv7zJy37LhGH6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/common": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ts-graphviz/common": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/common/-/common-3.0.4.tgz",
+      "integrity": "sha512-lwyjx7FAXLCh4/8bHWHRr45yj1GycoGz747XxF3rbJ2SDDpCC12De0cT06v2EuHqAwpq629+A9VDft5G/wRAIw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ts-graphviz/core": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/core/-/core-3.0.6.tgz",
+      "integrity": "sha512-5g/Tj1xoUgOnB0yhTe4uHR6WTm5zZSm6o79DihTHENOT5/dli70cAI28ousc8hB46N4PKEPqDMR5C/W/jCvtow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/ast": "^3.0.5",
+        "@ts-graphviz/common": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2705,6 +2792,31 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-graphviz": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/ts-graphviz/-/ts-graphviz-3.0.6.tgz",
+      "integrity": "sha512-NZAbgrRP4HPTgD/w032eQM2P1bEYv+peW+fiw4CreEKwZvqtWm2B7gi4Kon5fzRuP+VP8m7hpIBAWHT5rqEK6w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/adapter": "^3.0.5",
+        "@ts-graphviz/ast": "^3.0.5",
+        "@ts-graphviz/common": "^3.0.4",
+        "@ts-graphviz/core": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   "dependencies": {
     "commander": "^12.1.0",
     "elkjs": "^0.9.3",
-    "nanoid": "^5.0.9"
+    "nanoid": "^5.0.9",
+    "ts-graphviz": "^3.0.6"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/src/parser/dot-parser.ts
+++ b/src/parser/dot-parser.ts
@@ -77,6 +77,17 @@ function mapRankDir(rankdir: string | undefined): FlowDirection | undefined {
 }
 
 /**
+ * Check if a DOT style attribute contains a specific style value.
+ * DOT style attributes can be comma-separated (e.g., "filled,dashed").
+ * This function splits by comma and checks for exact matches to avoid
+ * false positives like "dashedline" matching "dashed".
+ */
+function hasStyleValue(styleAttr: string, value: string): boolean {
+  const styles = styleAttr.split(',').map((s) => s.trim().toLowerCase());
+  return styles.includes(value.toLowerCase());
+}
+
+/**
  * Extract node style from DOT attributes
  */
 function extractNodeStyle(node: NodeModel): NodeStyle | undefined {
@@ -97,10 +108,10 @@ function extractNodeStyle(node: NodeModel): NodeStyle | undefined {
 
   const styleAttr = node.attributes.get('style');
   if (styleAttr && typeof styleAttr === 'string') {
-    if (styleAttr.includes('dashed')) {
+    if (hasStyleValue(styleAttr, 'dashed')) {
       style.strokeStyle = 'dashed';
       hasStyle = true;
-    } else if (styleAttr.includes('dotted')) {
+    } else if (hasStyleValue(styleAttr, 'dotted')) {
       style.strokeStyle = 'dotted';
       hasStyle = true;
     }
@@ -124,10 +135,10 @@ function extractEdgeStyle(edge: EdgeModel): EdgeStyle | undefined {
 
   const styleAttr = edge.attributes.get('style');
   if (styleAttr && typeof styleAttr === 'string') {
-    if (styleAttr.includes('dashed')) {
+    if (hasStyleValue(styleAttr, 'dashed')) {
       style.strokeStyle = 'dashed';
       hasStyle = true;
-    } else if (styleAttr.includes('dotted')) {
+    } else if (hasStyleValue(styleAttr, 'dotted')) {
       style.strokeStyle = 'dotted';
       hasStyle = true;
     }

--- a/src/parser/dot-parser.ts
+++ b/src/parser/dot-parser.ts
@@ -1,0 +1,269 @@
+/**
+ * DOT/Graphviz Parser
+ *
+ * Parses DOT language syntax and converts to FlowchartGraph.
+ * Uses ts-graphviz library for parsing.
+ *
+ * Supported DOT features:
+ *   - digraph and graph declarations
+ *   - Node declarations with labels and shapes
+ *   - Edges: A -> B (directed) and A -- B (undirected)
+ *   - Edge labels: [label="text"]
+ *   - Node shapes: [shape=diamond|ellipse|box|cylinder]
+ *   - Graph direction: rankdir=TB|BT|LR|RL
+ *   - Dashed edges: [style=dashed]
+ *   - Subgraphs (flattened to regular nodes)
+ *   - Color attributes (fillcolor, color)
+ */
+
+import { fromDot, type RootGraphModel, type NodeModel, type EdgeModel, type SubgraphModel } from 'ts-graphviz';
+import { nanoid } from 'nanoid';
+import type {
+  FlowchartGraph,
+  GraphNode,
+  GraphEdge,
+  LayoutOptions,
+  NodeType,
+  FlowDirection,
+  NodeStyle,
+  EdgeStyle,
+} from '../types/dsl.js';
+import { DEFAULT_LAYOUT_OPTIONS } from '../types/dsl.js';
+
+/**
+ * Map DOT shape names to our NodeType
+ */
+function mapDotShape(dotShape: string | undefined): NodeType {
+  if (!dotShape) return 'rectangle';
+
+  const shape = dotShape.toLowerCase();
+
+  switch (shape) {
+    case 'ellipse':
+    case 'oval':
+    case 'circle':
+      return 'ellipse';
+    case 'diamond':
+      return 'diamond';
+    case 'cylinder':
+    case 'record':
+    case 'mrecord':
+      return 'database';
+    case 'box':
+    case 'rect':
+    case 'rectangle':
+    case 'square':
+    default:
+      return 'rectangle';
+  }
+}
+
+/**
+ * Map DOT rankdir to our FlowDirection
+ */
+function mapRankDir(rankdir: string | undefined): FlowDirection | undefined {
+  if (!rankdir) return undefined;
+
+  const dir = rankdir.toUpperCase();
+  if (dir === 'TB' || dir === 'BT' || dir === 'LR' || dir === 'RL') {
+    return dir as FlowDirection;
+  }
+  return undefined;
+}
+
+/**
+ * Extract node style from DOT attributes
+ */
+function extractNodeStyle(node: NodeModel): NodeStyle | undefined {
+  const style: NodeStyle = {};
+  let hasStyle = false;
+
+  const fillcolor = node.attributes.get('fillcolor');
+  if (fillcolor && typeof fillcolor === 'string') {
+    style.backgroundColor = fillcolor;
+    hasStyle = true;
+  }
+
+  const color = node.attributes.get('color');
+  if (color && typeof color === 'string') {
+    style.strokeColor = color;
+    hasStyle = true;
+  }
+
+  const styleAttr = node.attributes.get('style');
+  if (styleAttr && typeof styleAttr === 'string') {
+    if (styleAttr.includes('dashed')) {
+      style.strokeStyle = 'dashed';
+      hasStyle = true;
+    } else if (styleAttr.includes('dotted')) {
+      style.strokeStyle = 'dotted';
+      hasStyle = true;
+    }
+  }
+
+  return hasStyle ? style : undefined;
+}
+
+/**
+ * Extract edge style from DOT attributes
+ */
+function extractEdgeStyle(edge: EdgeModel): EdgeStyle | undefined {
+  const style: EdgeStyle = {};
+  let hasStyle = false;
+
+  const color = edge.attributes.get('color');
+  if (color && typeof color === 'string') {
+    style.strokeColor = color;
+    hasStyle = true;
+  }
+
+  const styleAttr = edge.attributes.get('style');
+  if (styleAttr && typeof styleAttr === 'string') {
+    if (styleAttr.includes('dashed')) {
+      style.strokeStyle = 'dashed';
+      hasStyle = true;
+    } else if (styleAttr.includes('dotted')) {
+      style.strokeStyle = 'dotted';
+      hasStyle = true;
+    }
+  }
+
+  return hasStyle ? style : undefined;
+}
+
+/**
+ * Get the node ID from an edge target (handles NodeModel and ForwardRefNode)
+ */
+function getNodeIdFromTarget(target: unknown): string | null {
+  if (!target) return null;
+
+  // Handle NodeModel
+  if (typeof target === 'object' && 'id' in target && typeof (target as { id: unknown }).id === 'string') {
+    return (target as { id: string }).id;
+  }
+
+  return null;
+}
+
+/**
+ * Recursively collect all nodes from a graph and its subgraphs
+ */
+function collectNodes(
+  graph: RootGraphModel | SubgraphModel,
+  nodeMap: Map<string, GraphNode>
+): void {
+  // Process nodes in this graph
+  for (const node of graph.nodes) {
+    if (nodeMap.has(node.id)) continue;
+
+    const label = node.attributes.get('label');
+    const shape = node.attributes.get('shape');
+    const nodeStyle = extractNodeStyle(node);
+
+    nodeMap.set(node.id, {
+      id: nanoid(10),
+      type: mapDotShape(typeof shape === 'string' ? shape : undefined),
+      label: typeof label === 'string' ? label : node.id,
+      style: nodeStyle,
+    });
+  }
+
+  // Recursively process subgraphs
+  for (const subgraph of graph.subgraphs) {
+    collectNodes(subgraph, nodeMap);
+  }
+}
+
+/**
+ * Recursively collect all edges from a graph and its subgraphs
+ */
+function collectEdges(
+  graph: RootGraphModel | SubgraphModel,
+  nodeMap: Map<string, GraphNode>,
+  edges: GraphEdge[]
+): void {
+  // Process edges in this graph
+  for (const edge of graph.edges) {
+    const targets = edge.targets;
+    if (!targets || targets.length < 2) continue;
+
+    // Process edge chain (A -> B -> C becomes A->B and B->C)
+    for (let i = 0; i < targets.length - 1; i++) {
+      const sourceId = getNodeIdFromTarget(targets[i]);
+      const targetId = getNodeIdFromTarget(targets[i + 1]);
+
+      if (!sourceId || !targetId) continue;
+
+      const sourceNode = nodeMap.get(sourceId);
+      const targetNode = nodeMap.get(targetId);
+
+      if (!sourceNode || !targetNode) continue;
+
+      const label = edge.attributes.get('label');
+      const edgeStyle = extractEdgeStyle(edge);
+
+      edges.push({
+        id: nanoid(10),
+        source: sourceNode.id,
+        target: targetNode.id,
+        label: typeof label === 'string' ? label : undefined,
+        style: edgeStyle,
+      });
+    }
+  }
+
+  // Recursively process subgraphs
+  for (const subgraph of graph.subgraphs) {
+    collectEdges(subgraph, nodeMap, edges);
+  }
+}
+
+/**
+ * Parse DOT string into a FlowchartGraph
+ */
+export function parseDOT(input: string): FlowchartGraph {
+  let rootGraph: RootGraphModel;
+
+  try {
+    rootGraph = fromDot(input);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid DOT syntax: ${message}`);
+  }
+
+  const options: LayoutOptions = { ...DEFAULT_LAYOUT_OPTIONS };
+
+  // Extract graph-level attributes
+  const rankdir = rootGraph.attributes.graph.get('rankdir');
+  const direction = mapRankDir(typeof rankdir === 'string' ? rankdir : undefined);
+  if (direction) {
+    options.direction = direction;
+  }
+
+  const nodesep = rootGraph.attributes.graph.get('nodesep');
+  if (typeof nodesep === 'number') {
+    // nodesep is in inches, convert to approximate pixels (72 dpi)
+    options.nodeSpacing = Math.round(nodesep * 72);
+  }
+
+  const ranksep = rootGraph.attributes.graph.get('ranksep');
+  if (typeof ranksep === 'number') {
+    // ranksep is in inches, convert to approximate pixels (72 dpi)
+    options.rankSpacing = Math.round(ranksep * 72);
+  }
+
+  // Collect all nodes (including from subgraphs)
+  const nodeMap = new Map<string, GraphNode>();
+  collectNodes(rootGraph, nodeMap);
+
+  // Collect all edges (including from subgraphs)
+  const edges: GraphEdge[] = [];
+  collectEdges(rootGraph, nodeMap, edges);
+
+  return {
+    nodes: Array.from(nodeMap.values()),
+    edges,
+    options,
+  };
+}
+

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -4,3 +4,4 @@
 
 export { parseDSL } from './dsl-parser.js';
 export { parseJSON, parseJSONString } from './json-parser.js';
+export { parseDOT } from './dot-parser.js';

--- a/tests/unit/parser/dot-parser.test.ts
+++ b/tests/unit/parser/dot-parser.test.ts
@@ -33,7 +33,7 @@ describe('DOT Parser', () => {
     });
 
     it('should parse circle nodes as ellipse', () => {
-      // Note: 'Node' is a reserved word in DOT, so we use 'MyNode'
+      // Note: 'node' (case-insensitive) is a DOT keyword for setting default node attributes
       const result = parseDOT('digraph { MyNode [shape=circle]; }');
       expect(result.nodes[0].type).toBe('ellipse');
     });
@@ -294,8 +294,10 @@ describe('DOT Parser', () => {
 
     it('should parse strict digraph', () => {
       const result = parseDOT('strict digraph { A -> B; A -> B; }');
-      // In strict mode, duplicate edges are merged
       expect(result.nodes).toHaveLength(2);
+      // In strict mode, duplicate edges should be merged by ts-graphviz
+      // The edge count depends on how ts-graphviz handles strict mode
+      expect(result.edges.length).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/tests/unit/parser/dot-parser.test.ts
+++ b/tests/unit/parser/dot-parser.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from 'vitest';
+import { parseDOT } from '../../../src/parser/dot-parser.js';
+
+describe('DOT Parser', () => {
+  describe('node parsing', () => {
+    it('should parse nodes from a simple digraph', () => {
+      const result = parseDOT('digraph { A; B; C; }');
+      expect(result.nodes).toHaveLength(3);
+      expect(result.nodes.map((n) => n.label).sort()).toEqual(['A', 'B', 'C']);
+    });
+
+    it('should parse rectangle nodes (default shape)', () => {
+      const result = parseDOT('digraph { A [shape=box]; }');
+      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes[0].type).toBe('rectangle');
+    });
+
+    it('should parse rectangle nodes with rect shape', () => {
+      const result = parseDOT('digraph { A [shape=rect]; }');
+      expect(result.nodes[0].type).toBe('rectangle');
+    });
+
+    it('should parse ellipse nodes', () => {
+      const result = parseDOT('digraph { Start [shape=ellipse]; }');
+      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes[0].type).toBe('ellipse');
+      expect(result.nodes[0].label).toBe('Start');
+    });
+
+    it('should parse oval nodes as ellipse', () => {
+      const result = parseDOT('digraph { End [shape=oval]; }');
+      expect(result.nodes[0].type).toBe('ellipse');
+    });
+
+    it('should parse circle nodes as ellipse', () => {
+      // Note: 'Node' is a reserved word in DOT, so we use 'MyNode'
+      const result = parseDOT('digraph { MyNode [shape=circle]; }');
+      expect(result.nodes[0].type).toBe('ellipse');
+    });
+
+    it('should parse diamond nodes', () => {
+      const result = parseDOT('digraph { Decision [shape=diamond]; }');
+      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes[0].type).toBe('diamond');
+    });
+
+    it('should parse cylinder nodes as database', () => {
+      const result = parseDOT('digraph { DB [shape=cylinder]; }');
+      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes[0].type).toBe('database');
+    });
+
+    it('should parse record nodes as database', () => {
+      const result = parseDOT('digraph { Storage [shape=record]; }');
+      expect(result.nodes[0].type).toBe('database');
+    });
+
+    it('should use label attribute when provided', () => {
+      const result = parseDOT('digraph { A [label="Process Step"]; }');
+      expect(result.nodes[0].label).toBe('Process Step');
+    });
+
+    it('should use node ID as label when no label attribute', () => {
+      const result = parseDOT('digraph { ProcessStep; }');
+      expect(result.nodes[0].label).toBe('ProcessStep');
+    });
+
+    it('should handle quoted node IDs', () => {
+      const result = parseDOT('digraph { "Node With Spaces"; }');
+      expect(result.nodes[0].label).toBe('Node With Spaces');
+    });
+  });
+
+  describe('edge parsing', () => {
+    it('should parse simple directed edges', () => {
+      const result = parseDOT('digraph { A -> B; }');
+      expect(result.nodes).toHaveLength(2);
+      expect(result.edges).toHaveLength(1);
+
+      const sourceNode = result.nodes.find((n) => n.label === 'A');
+      const targetNode = result.nodes.find((n) => n.label === 'B');
+      expect(result.edges[0].source).toBe(sourceNode?.id);
+      expect(result.edges[0].target).toBe(targetNode?.id);
+    });
+
+    it('should parse edge chains', () => {
+      const result = parseDOT('digraph { A -> B -> C; }');
+      expect(result.nodes).toHaveLength(3);
+      expect(result.edges).toHaveLength(2);
+    });
+
+    it('should parse multiple edges', () => {
+      const result = parseDOT('digraph { A -> B; B -> C; C -> A; }');
+      expect(result.edges).toHaveLength(3);
+    });
+
+    it('should parse labeled edges', () => {
+      const result = parseDOT('digraph { A -> B [label="yes"]; }');
+      expect(result.edges[0].label).toBe('yes');
+    });
+
+    it('should parse dashed edges', () => {
+      const result = parseDOT('digraph { A -> B [style=dashed]; }');
+      expect(result.edges[0].style?.strokeStyle).toBe('dashed');
+    });
+
+    it('should parse dotted edges', () => {
+      const result = parseDOT('digraph { A -> B [style=dotted]; }');
+      expect(result.edges[0].style?.strokeStyle).toBe('dotted');
+    });
+
+    it('should parse edge color', () => {
+      const result = parseDOT('digraph { A -> B [color=red]; }');
+      expect(result.edges[0].style?.strokeColor).toBe('red');
+    });
+
+    it('should parse undirected graph edges', () => {
+      const result = parseDOT('graph { A -- B; }');
+      expect(result.nodes).toHaveLength(2);
+      expect(result.edges).toHaveLength(1);
+    });
+  });
+
+  describe('direction/layout options', () => {
+    it('should parse rankdir TB', () => {
+      const result = parseDOT('digraph { rankdir=TB; A -> B; }');
+      expect(result.options.direction).toBe('TB');
+    });
+
+    it('should parse rankdir LR', () => {
+      const result = parseDOT('digraph { rankdir=LR; A -> B; }');
+      expect(result.options.direction).toBe('LR');
+    });
+
+    it('should parse rankdir BT', () => {
+      const result = parseDOT('digraph { rankdir=BT; A -> B; }');
+      expect(result.options.direction).toBe('BT');
+    });
+
+    it('should parse rankdir RL', () => {
+      const result = parseDOT('digraph { rankdir=RL; A -> B; }');
+      expect(result.options.direction).toBe('RL');
+    });
+
+    it('should default to TB when no rankdir specified', () => {
+      const result = parseDOT('digraph { A -> B; }');
+      expect(result.options.direction).toBe('TB');
+    });
+  });
+
+  describe('node styles', () => {
+    it('should parse fillcolor attribute', () => {
+      const result = parseDOT('digraph { A [fillcolor=lightblue]; }');
+      expect(result.nodes[0].style?.backgroundColor).toBe('lightblue');
+    });
+
+    it('should parse color attribute as stroke color', () => {
+      const result = parseDOT('digraph { A [color=red]; }');
+      expect(result.nodes[0].style?.strokeColor).toBe('red');
+    });
+
+    it('should parse dashed node style', () => {
+      const result = parseDOT('digraph { A [style=dashed]; }');
+      expect(result.nodes[0].style?.strokeStyle).toBe('dashed');
+    });
+  });
+
+  describe('subgraph handling', () => {
+    it('should flatten subgraph nodes to main graph', () => {
+      const result = parseDOT(`
+        digraph {
+          subgraph cluster_0 {
+            A; B;
+          }
+          C;
+        }
+      `);
+      expect(result.nodes).toHaveLength(3);
+      expect(result.nodes.map((n) => n.label).sort()).toEqual(['A', 'B', 'C']);
+    });
+
+    it('should preserve edges within subgraphs', () => {
+      const result = parseDOT(`
+        digraph {
+          subgraph cluster_0 {
+            A -> B;
+          }
+          B -> C;
+        }
+      `);
+      expect(result.edges).toHaveLength(2);
+    });
+
+    it('should handle nested subgraphs', () => {
+      const result = parseDOT(`
+        digraph {
+          subgraph cluster_outer {
+            subgraph cluster_inner {
+              A;
+            }
+            B;
+          }
+          C;
+        }
+      `);
+      expect(result.nodes).toHaveLength(3);
+    });
+  });
+
+  describe('complex flowcharts', () => {
+    it('should parse a decision tree flowchart', () => {
+      const dot = `
+        digraph {
+          rankdir=TB;
+          
+          Start [shape=ellipse];
+          Process [shape=box];
+          Decision [shape=diamond];
+          End [shape=ellipse];
+          
+          Start -> Process;
+          Process -> Decision;
+          Decision -> End [label="yes"];
+          Decision -> Process [label="no"];
+        }
+      `;
+      const result = parseDOT(dot);
+
+      expect(result.nodes).toHaveLength(4);
+      expect(result.edges).toHaveLength(4);
+
+      const startNode = result.nodes.find((n) => n.label === 'Start');
+      const decisionNode = result.nodes.find((n) => n.label === 'Decision');
+      expect(startNode?.type).toBe('ellipse');
+      expect(decisionNode?.type).toBe('diamond');
+
+      const yesEdge = result.edges.find((e) => e.label === 'yes');
+      const noEdge = result.edges.find((e) => e.label === 'no');
+      expect(yesEdge).toBeDefined();
+      expect(noEdge).toBeDefined();
+    });
+
+    it('should parse a login flow from the issue example', () => {
+      const dot = `
+        digraph {
+          Start -> Process -> Decision;
+          Decision -> End [label="yes"];
+          Decision -> Process [label="no"];
+          
+          Start [shape=ellipse];
+          Decision [shape=diamond];
+          End [shape=ellipse];
+        }
+      `;
+      const result = parseDOT(dot);
+
+      expect(result.nodes.length).toBeGreaterThanOrEqual(4);
+      expect(result.edges.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('should deduplicate nodes referenced multiple times', () => {
+      const result = parseDOT('digraph { A -> B; B -> C; A -> C; }');
+      expect(result.nodes).toHaveLength(3);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw on invalid DOT syntax', () => {
+      expect(() => parseDOT('not valid dot')).toThrow('Invalid DOT syntax');
+    });
+
+    it('should throw on unclosed braces', () => {
+      expect(() => parseDOT('digraph { A -> B')).toThrow();
+    });
+
+    it('should handle empty digraph', () => {
+      const result = parseDOT('digraph {}');
+      expect(result.nodes).toHaveLength(0);
+      expect(result.edges).toHaveLength(0);
+    });
+
+    it('should handle digraph with only whitespace', () => {
+      const result = parseDOT('digraph {   }');
+      expect(result.nodes).toHaveLength(0);
+    });
+  });
+
+  describe('named graphs', () => {
+    it('should parse named digraph', () => {
+      const result = parseDOT('digraph MyGraph { A -> B; }');
+      expect(result.nodes).toHaveLength(2);
+      expect(result.edges).toHaveLength(1);
+    });
+
+    it('should parse strict digraph', () => {
+      const result = parseDOT('strict digraph { A -> B; A -> B; }');
+      // In strict mode, duplicate edges are merged
+      expect(result.nodes).toHaveLength(2);
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary

Implements the feature request from #6 - adds support for DOT/Graphviz syntax as an alternative input format.

## Changes

### New: DOT Parser (`src/parser/dot-parser.ts`)
- Uses `ts-graphviz` library for robust DOT parsing
- Maps DOT shapes to Excalidraw node types:
  - `box`, `rect`, `rectangle` → rectangle
  - `ellipse`, `oval`, `circle` → ellipse
  - `diamond` → diamond
  - `cylinder`, `record` → database
- Supports `rankdir` for layout direction (TB, BT, LR, RL)
- Supports edge labels via `[label="text"]`
- Supports dashed/dotted styles via `[style=dashed]`
- Supports color attributes (`color`, `fillcolor`)
- Flattens subgraphs to regular nodes while preserving edges

### CLI Integration
- Added `--format dot` option
- Auto-detects `.dot` and `.gv` file extensions
- Works with `--inline` and `--stdin` inputs

## Usage Examples

```bash
# From file (auto-detects format)
excalidraw-cli create diagram.dot -o output.excalidraw

# With explicit format flag
excalidraw-cli create graph.txt --format dot -o output.excalidraw

# Inline DOT
excalidraw-cli create --inline "digraph { A -> B -> C }" --format dot -o flow.excalidraw
```

## DOT Example

```dot
digraph {
  rankdir=LR;
  
  Start [shape=ellipse];
  Process [shape=box];
  Decision [shape=diamond];
  End [shape=ellipse];
  
  Start -> Process -> Decision;
  Decision -> End [label="yes"];
  Decision -> Process [label="no"];
}
```

## Testing

- Added 40 comprehensive unit tests for the DOT parser
- All 52 tests pass (12 existing + 40 new)
- Build compiles successfully

Closes #6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DOT/Graphviz format support: users can now input flowcharts using DOT syntax (.dot and .gv file extensions)
  * DOT format integrated into CLI create and parse commands alongside DSL and JSON formats
  * Automatic format detection for DOT files

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->