### PR TITLE
release: Add Image Support & DOT/Graphviz Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@
 
 ## Installation
 
+### Using the npm
+
+```bash
+npm i @swiftlysingh/excalidraw-cli
+```
+
 ### From Source (Local Development)
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
-  "name": "excalidraw-cli",
+  "name": "@swiftlysingh/excalidraw-cli",
   "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "excalidraw-cli",
+      "name": "@swiftlysingh/excalidraw-cli",
       "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "commander": "^12.1.0",
         "elkjs": "^0.9.3",
-        "nanoid": "^5.0.9"
+        "nanoid": "^5.0.9",
+        "ts-graphviz": "^3.0.6"
       },
       "bin": {
         "excalidraw-cli": "dist/cli.js"
@@ -1017,6 +1018,92 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@ts-graphviz/adapter": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/adapter/-/adapter-3.0.5.tgz",
+      "integrity": "sha512-l6U+jizdkgnwq8Gb4I/Azgr/TGM452ovx2SLxUU/mGZNtrdOol4qi7Gn+d5hP3weBKkUNV9C7j1Xawg4w1DkCw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/common": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ts-graphviz/ast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/ast/-/ast-3.0.5.tgz",
+      "integrity": "sha512-gwrhTWspMU0qIP8V3yLnwUcnV+pJuPRTp5RAzpqYlKcD7NIsMtZfCzN2fzg8SpkJFC5S/9Ajlv7zJy37LhGH6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/common": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ts-graphviz/common": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/common/-/common-3.0.4.tgz",
+      "integrity": "sha512-lwyjx7FAXLCh4/8bHWHRr45yj1GycoGz747XxF3rbJ2SDDpCC12De0cT06v2EuHqAwpq629+A9VDft5G/wRAIw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@ts-graphviz/core": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@ts-graphviz/core/-/core-3.0.6.tgz",
+      "integrity": "sha512-5g/Tj1xoUgOnB0yhTe4uHR6WTm5zZSm6o79DihTHENOT5/dli70cAI28ousc8hB46N4PKEPqDMR5C/W/jCvtow==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/ast": "^3.0.5",
+        "@ts-graphviz/common": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2705,6 +2792,31 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-graphviz": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/ts-graphviz/-/ts-graphviz-3.0.6.tgz",
+      "integrity": "sha512-NZAbgrRP4HPTgD/w032eQM2P1bEYv+peW+fiw4CreEKwZvqtWm2B7gi4Kon5fzRuP+VP8m7hpIBAWHT5rqEK6w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ts-graphviz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ts-graphviz"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ts-graphviz/adapter": "^3.0.5",
+        "@ts-graphviz/ast": "^3.0.5",
+        "@ts-graphviz/common": "^3.0.4",
+        "@ts-graphviz/core": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/type-check": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
   "dependencies": {
     "commander": "^12.1.0",
     "elkjs": "^0.9.3",
-    "nanoid": "^5.0.9"
+    "nanoid": "^5.0.9",
+    "ts-graphviz": "^3.0.6"
   },
   "devDependencies": {
     "@types/node": "^22.10.5",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,7 +20,7 @@ const program = new Command();
 program
   .name('excalidraw-cli')
   .description('Create Excalidraw flowcharts from DSL, JSON, or DOT')
-  .version('1.0.0');
+  .version('1.0.1');
 
 /**
  * Create command - main flowchart creation
@@ -36,10 +36,11 @@ program
   .option('-d, --direction <dir>', 'Flow direction: TB, BT, LR, RL (default: TB)')
   .option('-s, --spacing <n>', 'Node spacing in pixels', '50')
   .option('--verbose', 'Verbose output')
-  .action(async (inputFile, options) => {
+  .action(async (inputFile, options, command) => {
     try {
       let input: string;
       let format = options.format;
+      const formatExplicitlySet = command.getOptionValueSource('format') === 'cli';
 
       // Get input from various sources
       if (options.inline) {
@@ -49,11 +50,13 @@ program
       } else if (inputFile) {
         input = readFileSync(inputFile, 'utf-8');
 
-        // Auto-detect format from file extension
-        if (inputFile.endsWith('.json')) {
-          format = 'json';
-        } else if (inputFile.endsWith('.dot') || inputFile.endsWith('.gv')) {
-          format = 'dot';
+        // Auto-detect format from file extension (only if --format not explicitly set)
+        if (!formatExplicitlySet) {
+          if (inputFile.endsWith('.json')) {
+            format = 'json';
+          } else if (inputFile.endsWith('.dot') || inputFile.endsWith('.gv')) {
+            format = 'dot';
+          }
         }
       } else {
         console.error('Error: No input provided. Use --inline, --stdin, or provide an input file.');
@@ -126,16 +129,19 @@ program
   .description('Parse and validate input without generating output')
   .argument('<input>', 'Input file path')
   .option('-f, --format <type>', 'Input format: dsl, json, dot (default: dsl)', 'dsl')
-  .action((inputFile, options) => {
+  .action((inputFile, options, command) => {
     try {
       const input = readFileSync(inputFile, 'utf-8');
       let format = options.format;
+      const formatExplicitlySet = command.getOptionValueSource('format') === 'cli';
 
-      // Auto-detect format from file extension
-      if (inputFile.endsWith('.json')) {
-        format = 'json';
-      } else if (inputFile.endsWith('.dot') || inputFile.endsWith('.gv')) {
-        format = 'dot';
+      // Auto-detect format from file extension (only if --format not explicitly set)
+      if (!formatExplicitlySet) {
+        if (inputFile.endsWith('.json')) {
+          format = 'json';
+        } else if (inputFile.endsWith('.dot') || inputFile.endsWith('.gv')) {
+          format = 'dot';
+        }
       }
 
       // Parse input

--- a/src/factory/image-factory.ts
+++ b/src/factory/image-factory.ts
@@ -1,0 +1,208 @@
+/**
+ * Image Factory
+ *
+ * Creates Excalidraw image elements and handles image file data.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { nanoid } from 'nanoid';
+import { createBaseElement } from './element-factory.js';
+import type { ExcalidrawImage, ExcalidrawFileData } from '../types/excalidraw.js';
+import type { LayoutedNode, LayoutedImage } from '../types/dsl.js';
+
+/**
+ * Default image dimensions
+ */
+const DEFAULT_IMAGE_WIDTH = 100;
+const DEFAULT_IMAGE_HEIGHT = 100;
+
+/**
+ * MIME type mapping by file extension
+ */
+const MIME_TYPES: Record<string, string> = {
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.svg': 'image/svg+xml',
+  '.bmp': 'image/bmp',
+  '.ico': 'image/x-icon',
+};
+
+/**
+ * Get MIME type from file path or URL
+ */
+function getMimeType(src: string): string {
+  const ext = path.extname(src).toLowerCase();
+  return MIME_TYPES[ext] || 'image/png';
+}
+
+/**
+ * Check if source is a URL
+ */
+function isUrl(src: string): boolean {
+  return src.startsWith('http://') || src.startsWith('https://');
+}
+
+/**
+ * Check if source is a sticker reference
+ */
+function isSticker(src: string): boolean {
+  return src.startsWith('sticker:');
+}
+
+/**
+ * Resolve sticker name to actual path using library
+ */
+export function resolveStickerPath(stickerSrc: string, libraryPath?: string): string {
+  const name = stickerSrc.replace('sticker:', '');
+
+  if (!libraryPath) {
+    // No library specified, return as-is (will fail gracefully)
+    return name;
+  }
+
+  // Try common extensions
+  const extensions = ['.png', '.svg', '.jpg', '.jpeg', '.gif', '.webp'];
+  for (const ext of extensions) {
+    const fullPath = path.join(libraryPath, `${name}${ext}`);
+    if (fs.existsSync(fullPath)) {
+      return fullPath;
+    }
+  }
+
+  // Try with the name as-is (might already have extension)
+  const directPath = path.join(libraryPath, name);
+  if (fs.existsSync(directPath)) {
+    return directPath;
+  }
+
+  return name;
+}
+
+/**
+ * Create file data for an image
+ * For local files: reads and base64 encodes
+ * For URLs: stores the URL directly (Excalidraw supports this)
+ */
+export function createFileData(
+  src: string,
+  fileId: string,
+  libraryPath?: string
+): ExcalidrawFileData | null {
+  // Handle sticker references
+  let resolvedSrc = src;
+  if (isSticker(src)) {
+    resolvedSrc = resolveStickerPath(src, libraryPath);
+  }
+
+  // For URLs, store directly without fetching
+  if (isUrl(resolvedSrc)) {
+    return {
+      mimeType: getMimeType(resolvedSrc),
+      id: fileId,
+      dataURL: resolvedSrc,
+      created: Date.now(),
+    };
+  }
+
+  // For local files, read and base64 encode
+  try {
+    const absolutePath = path.isAbsolute(resolvedSrc)
+      ? resolvedSrc
+      : path.resolve(process.cwd(), resolvedSrc);
+
+    if (!fs.existsSync(absolutePath)) {
+      console.warn(`Image file not found: ${absolutePath}`);
+      return null;
+    }
+
+    const buffer = fs.readFileSync(absolutePath);
+    const base64 = buffer.toString('base64');
+    const mimeType = getMimeType(resolvedSrc);
+    const dataURL = `data:${mimeType};base64,${base64}`;
+
+    return {
+      mimeType,
+      id: fileId,
+      dataURL,
+      created: Date.now(),
+    };
+  } catch (error) {
+    console.warn(`Failed to read image file: ${resolvedSrc}`, error);
+    return null;
+  }
+}
+
+/**
+ * Create an image element for a layouted node
+ */
+export function createImageElement(
+  node: LayoutedNode,
+  fileId: string
+): ExcalidrawImage {
+  return {
+    ...createBaseElement('image', node.x, node.y, node.width, node.height, {
+      id: node.id,
+      roundness: null,
+      boundElements: null,
+      backgroundColor: 'transparent',
+    }),
+    type: 'image',
+    fileId,
+    status: 'saved',
+    scale: [1, 1],
+  } as ExcalidrawImage;
+}
+
+/**
+ * Create an image element for a layouted positioned image
+ */
+export function createPositionedImageElement(
+  image: LayoutedImage,
+  fileId: string
+): ExcalidrawImage {
+  return {
+    ...createBaseElement('image', image.x, image.y, image.width, image.height, {
+      id: image.id,
+      roundness: null,
+      boundElements: null,
+      backgroundColor: 'transparent',
+    }),
+    type: 'image',
+    fileId,
+    status: 'saved',
+    scale: [1, 1],
+  } as ExcalidrawImage;
+}
+
+/**
+ * Generate a unique file ID
+ */
+export function generateFileId(): string {
+  return nanoid(21);
+}
+
+/**
+ * Get image dimensions (for layout calculation)
+ * Returns explicit dimensions if provided, otherwise defaults
+ */
+export function getImageDimensions(
+  src: string,
+  explicitWidth?: number,
+  explicitHeight?: number
+): { width: number; height: number } {
+  // Use explicit dimensions if provided
+  if (explicitWidth && explicitHeight) {
+    return { width: explicitWidth, height: explicitHeight };
+  }
+
+  // For local files, we could probe the actual dimensions, but that adds complexity
+  // For now, use defaults and let users specify dimensions if needed
+  return {
+    width: explicitWidth || DEFAULT_IMAGE_WIDTH,
+    height: explicitHeight || DEFAULT_IMAGE_HEIGHT,
+  };
+}

--- a/src/factory/image-factory.ts
+++ b/src/factory/image-factory.ts
@@ -98,14 +98,13 @@ export function createFileData(
     resolvedSrc = resolveStickerPath(src, libraryPath);
   }
 
-  // For URLs, store directly without fetching
+  // Remote URLs are not supported - Excalidraw requires base64-encoded data URLs
   if (isUrl(resolvedSrc)) {
-    return {
-      mimeType: getMimeType(resolvedSrc),
-      id: fileId,
-      dataURL: resolvedSrc,
-      created: Date.now(),
-    };
+    console.warn(
+      `Remote URLs are not supported for images: ${resolvedSrc}\n` +
+        `  Download the image locally and use a file path instead.`
+    );
+    return null;
   }
 
   // For local files, read and base64 encode

--- a/src/factory/index.ts
+++ b/src/factory/index.ts
@@ -6,3 +6,11 @@ export { createBaseElement, resetIndexCounter, DEFAULT_ELEMENT_STYLE } from './e
 export { createNode, createRectangle, createDiamond, createEllipse } from './node-factory.js';
 export { createArrow, createArrowWithBindings } from './connection-factory.js';
 export { createText, createBoundText, createNodeLabel, createEdgeLabel } from './text-factory.js';
+export {
+  createImageElement,
+  createPositionedImageElement,
+  createFileData,
+  generateFileId,
+  getImageDimensions,
+  resolveStickerPath,
+} from './image-factory.js';

--- a/src/factory/text-factory.ts
+++ b/src/factory/text-factory.ts
@@ -8,7 +8,6 @@ import { nanoid } from 'nanoid';
 import { createBaseElement } from './element-factory.js';
 import type {
   ExcalidrawText,
-  FONT_FAMILIES,
   ExcalidrawTextAlign,
   ExcalidrawVerticalAlign,
 } from '../types/excalidraw.js';

--- a/src/generator/excalidraw-generator.ts
+++ b/src/generator/excalidraw-generator.ts
@@ -27,10 +27,8 @@ import { DEFAULT_APP_STATE } from '../types/excalidraw.js';
 import type {
   LayoutedGraph,
   LayoutedNode,
-  LayoutedEdge,
   LayoutedImage,
   ScatterConfig,
-  NodeDecoration,
   DecorationAnchor,
 } from '../types/dsl.js';
 
@@ -227,7 +225,7 @@ export function generateExcalidraw(graph: LayoutedGraph): ExcalidrawFile {
         edge.id
       );
       // Override the text element ID to match what we bound
-      (textElement as any).id = `text-${edge.id}`;
+      (textElement as { id: string }).id = `text-${edge.id}`;
       elements.push(textElement);
     }
   }

--- a/src/generator/excalidraw-generator.ts
+++ b/src/generator/excalidraw-generator.ts
@@ -4,16 +4,110 @@
  * Assembles a complete Excalidraw file from a layouted graph.
  */
 
-import { createNode, createArrow, createNodeLabel, createEdgeLabel, resetIndexCounter } from '../factory/index.js';
+import { nanoid } from 'nanoid';
+import {
+  createNode,
+  createArrow,
+  createNodeLabel,
+  createEdgeLabel,
+  resetIndexCounter,
+  createImageElement,
+  createPositionedImageElement,
+  createFileData,
+  generateFileId,
+  getImageDimensions,
+} from '../factory/index.js';
 import type {
   ExcalidrawFile,
   ExcalidrawElement,
   ExcalidrawBoundElement,
+  ExcalidrawFileData,
 } from '../types/excalidraw.js';
 import { DEFAULT_APP_STATE } from '../types/excalidraw.js';
-import type { LayoutedGraph, LayoutedNode, LayoutedEdge } from '../types/dsl.js';
+import type {
+  LayoutedGraph,
+  LayoutedNode,
+  LayoutedEdge,
+  LayoutedImage,
+  ScatterConfig,
+  NodeDecoration,
+  DecorationAnchor,
+} from '../types/dsl.js';
 
 const SOURCE_URL = 'https://github.com/swiftlysingh/excalidraw-cli';
+
+/**
+ * Calculate decoration position offset
+ */
+function getDecorationOffset(
+  anchor: DecorationAnchor,
+  nodeWidth: number,
+  nodeHeight: number,
+  imageWidth: number,
+  imageHeight: number
+): { x: number; y: number } {
+  const margin = 5;
+
+  switch (anchor) {
+    case 'top':
+      return { x: (nodeWidth - imageWidth) / 2, y: -imageHeight - margin };
+    case 'bottom':
+      return { x: (nodeWidth - imageWidth) / 2, y: nodeHeight + margin };
+    case 'left':
+      return { x: -imageWidth - margin, y: (nodeHeight - imageHeight) / 2 };
+    case 'right':
+      return { x: nodeWidth + margin, y: (nodeHeight - imageHeight) / 2 };
+    case 'top-left':
+      return { x: -imageWidth / 2, y: -imageHeight / 2 };
+    case 'top-right':
+      return { x: nodeWidth - imageWidth / 2, y: -imageHeight / 2 };
+    case 'bottom-left':
+      return { x: -imageWidth / 2, y: nodeHeight - imageHeight / 2 };
+    case 'bottom-right':
+      return { x: nodeWidth - imageWidth / 2, y: nodeHeight - imageHeight / 2 };
+    default:
+      return { x: nodeWidth - imageWidth / 2, y: -imageHeight / 2 };
+  }
+}
+
+/**
+ * Generate scattered images across the canvas
+ */
+function generateScatteredImages(
+  scatter: ScatterConfig[],
+  canvasWidth: number,
+  canvasHeight: number,
+  elements: ExcalidrawElement[],
+  files: Record<string, ExcalidrawFileData>,
+  libraryPath?: string
+): void {
+  for (const config of scatter) {
+    const width = config.width || 30;
+    const height = config.height || 30;
+
+    // Generate random positions avoiding the center area
+    for (let i = 0; i < config.count; i++) {
+      const x = Math.random() * (canvasWidth - width);
+      const y = Math.random() * (canvasHeight - height);
+
+      const fileId = generateFileId();
+      const imageId = nanoid(10);
+
+      // Create file data
+      const fileData = createFileData(config.src, fileId, libraryPath);
+      if (fileData) {
+        files[fileId] = fileData;
+
+        // Create image element
+        const imageElement = createPositionedImageElement(
+          { id: imageId, src: config.src, x, y, width, height },
+          fileId
+        );
+        elements.unshift(imageElement); // Add at beginning for lower z-index
+      }
+    }
+  }
+}
 
 /**
  * Generate an Excalidraw file from a layouted graph
@@ -23,6 +117,7 @@ export function generateExcalidraw(graph: LayoutedGraph): ExcalidrawFile {
   resetIndexCounter();
 
   const elements: ExcalidrawElement[] = [];
+  const files: Record<string, ExcalidrawFileData> = {};
 
   // Build a map of node IDs to nodes for quick lookup
   const nodeMap = new Map<string, LayoutedNode>();
@@ -30,43 +125,80 @@ export function generateExcalidraw(graph: LayoutedGraph): ExcalidrawFile {
     nodeMap.set(node.id, node);
   }
 
-  // Calculate bound elements for each node
+  // Calculate bound elements for each node (only for non-image nodes)
   const nodeBoundElements = new Map<string, ExcalidrawBoundElement[]>();
 
   for (const edge of graph.edges) {
-    // Add arrow as bound element to source node
-    if (!nodeBoundElements.has(edge.source)) {
-      nodeBoundElements.set(edge.source, []);
-    }
-    nodeBoundElements.get(edge.source)!.push({ id: edge.id, type: 'arrow' });
+    const sourceNode = nodeMap.get(edge.source);
+    const targetNode = nodeMap.get(edge.target);
 
-    // Add arrow as bound element to target node
-    if (!nodeBoundElements.has(edge.target)) {
-      nodeBoundElements.set(edge.target, []);
-    }
-    nodeBoundElements.get(edge.target)!.push({ id: edge.id, type: 'arrow' });
-  }
-
-  // Create shape elements for nodes
-  for (const node of graph.nodes) {
-    const boundElements = nodeBoundElements.get(node.id);
-    const shapeElement = createNode(node, boundElements);
-    elements.push(shapeElement);
-
-    // Create text label for the node
-    const textElement = createNodeLabel(node);
-    elements.push(textElement);
-  }
-
-  // Calculate bound elements for arrows (text labels)
-  const arrowBoundElements = new Map<string, ExcalidrawBoundElement[]>();
-
-  for (const edge of graph.edges) {
-    if (edge.label) {
-      if (!arrowBoundElements.has(edge.id)) {
-        arrowBoundElements.set(edge.id, []);
+    // Only bind arrows to shape nodes, not image nodes
+    if (sourceNode && sourceNode.type !== 'image') {
+      if (!nodeBoundElements.has(edge.source)) {
+        nodeBoundElements.set(edge.source, []);
       }
-      // Text element ID will be generated when we create it
+      nodeBoundElements.get(edge.source)!.push({ id: edge.id, type: 'arrow' });
+    }
+
+    if (targetNode && targetNode.type !== 'image') {
+      if (!nodeBoundElements.has(edge.target)) {
+        nodeBoundElements.set(edge.target, []);
+      }
+      nodeBoundElements.get(edge.target)!.push({ id: edge.id, type: 'arrow' });
+    }
+  }
+
+  // Create elements for nodes
+  for (const node of graph.nodes) {
+    if (node.type === 'image' && node.image) {
+      // Create image element
+      const fileId = generateFileId();
+      const fileData = createFileData(node.image.src, fileId, graph.library);
+      if (fileData) {
+        files[fileId] = fileData;
+        const imageElement = createImageElement(node, fileId);
+        elements.push(imageElement);
+      }
+    } else {
+      // Create shape element
+      const boundElements = nodeBoundElements.get(node.id);
+      const shapeElement = createNode(node, boundElements);
+      elements.push(shapeElement);
+
+      // Create text label for the node
+      const textElement = createNodeLabel(node);
+      elements.push(textElement);
+
+      // Create decoration images for this node
+      if (node.decorations) {
+        for (const decoration of node.decorations) {
+          const dims = getImageDimensions(decoration.src, decoration.width, decoration.height);
+          const offset = getDecorationOffset(
+            decoration.anchor,
+            node.width,
+            node.height,
+            dims.width,
+            dims.height
+          );
+
+          const fileId = generateFileId();
+          const fileData = createFileData(decoration.src, fileId, graph.library);
+          if (fileData) {
+            files[fileId] = fileData;
+
+            const decorationImage: LayoutedImage = {
+              id: nanoid(10),
+              src: decoration.src,
+              x: node.x + offset.x,
+              y: node.y + offset.y,
+              width: dims.width,
+              height: dims.height,
+            };
+            const imageElement = createPositionedImageElement(decorationImage, fileId);
+            elements.push(imageElement);
+          }
+        }
+      }
     }
   }
 
@@ -100,13 +232,38 @@ export function generateExcalidraw(graph: LayoutedGraph): ExcalidrawFile {
     }
   }
 
+  // Create positioned images (from @image directives)
+  if (graph.images) {
+    for (const image of graph.images) {
+      const fileId = generateFileId();
+      const fileData = createFileData(image.src, fileId, graph.library);
+      if (fileData) {
+        files[fileId] = fileData;
+        const imageElement = createPositionedImageElement(image, fileId);
+        elements.push(imageElement);
+      }
+    }
+  }
+
+  // Generate scattered images (from @scatter directives)
+  if (graph.scatter && graph.scatter.length > 0) {
+    generateScatteredImages(
+      graph.scatter,
+      graph.width,
+      graph.height,
+      elements,
+      files,
+      graph.library
+    );
+  }
+
   return {
     type: 'excalidraw',
     version: 2,
     source: SOURCE_URL,
     elements,
     appState: { ...DEFAULT_APP_STATE },
-    files: {},
+    files,
   };
 }
 

--- a/src/layout/elk-layout.ts
+++ b/src/layout/elk-layout.ts
@@ -12,9 +12,13 @@ import type {
   LayoutedGraph,
   LayoutedNode,
   LayoutedEdge,
+  LayoutedImage,
   LayoutOptions,
   GraphNode,
+  PositionedImage,
+  DecorationAnchor,
 } from '../types/dsl.js';
+import { getImageDimensions } from '../factory/image-factory.js';
 
 // ELK types
 interface ElkNode {
@@ -49,6 +53,11 @@ interface ElkGraph {
  * Calculate node dimensions based on label and type
  */
 function calculateNodeDimensions(node: GraphNode): { width: number; height: number } {
+  // Handle image nodes specially
+  if (node.type === 'image' && node.image) {
+    return getImageDimensions(node.image.src, node.image.width, node.image.height);
+  }
+
   const lines = node.label.split('\n');
   const maxLineLength = Math.max(...lines.map((l) => l.length));
   const lineCount = lines.length;
@@ -229,11 +238,130 @@ export async function layoutGraph(graph: FlowchartGraph): Promise<LayoutedGraph>
     maxY = Math.max(maxY, node.y + node.height);
   }
 
-  return {
+  const canvasWidth = maxX + graph.options.padding;
+  const canvasHeight = maxY + graph.options.padding;
+
+  // Resolve positioned images
+  const layoutedImages = resolvePositionedImages(
+    graph.images || [],
+    layoutedNodes,
+    canvasWidth,
+    canvasHeight
+  );
+
+  const result: LayoutedGraph = {
     nodes: layoutedNodes,
     edges: layoutedEdges,
     options: graph.options,
-    width: maxX + graph.options.padding,
-    height: maxY + graph.options.padding,
+    width: canvasWidth,
+    height: canvasHeight,
   };
+
+  if (layoutedImages.length > 0) result.images = layoutedImages;
+  if (graph.scatter && graph.scatter.length > 0) result.scatter = graph.scatter;
+  if (graph.library) result.library = graph.library;
+
+  return result;
+}
+
+/**
+ * Calculate position offset for decoration anchor
+ */
+function getAnchorOffset(
+  anchor: DecorationAnchor | undefined,
+  nodeWidth: number,
+  nodeHeight: number,
+  imageWidth: number,
+  imageHeight: number
+): { x: number; y: number } {
+  const margin = 5; // Small margin from node edge
+
+  switch (anchor) {
+    case 'top':
+      return { x: (nodeWidth - imageWidth) / 2, y: -imageHeight - margin };
+    case 'bottom':
+      return { x: (nodeWidth - imageWidth) / 2, y: nodeHeight + margin };
+    case 'left':
+      return { x: -imageWidth - margin, y: (nodeHeight - imageHeight) / 2 };
+    case 'right':
+      return { x: nodeWidth + margin, y: (nodeHeight - imageHeight) / 2 };
+    case 'top-left':
+      return { x: -imageWidth / 2, y: -imageHeight / 2 };
+    case 'top-right':
+      return { x: nodeWidth - imageWidth / 2, y: -imageHeight / 2 };
+    case 'bottom-left':
+      return { x: -imageWidth / 2, y: nodeHeight - imageHeight / 2 };
+    case 'bottom-right':
+      return { x: nodeWidth - imageWidth / 2, y: nodeHeight - imageHeight / 2 };
+    default:
+      // Default to top-right
+      return { x: nodeWidth - imageWidth / 2, y: -imageHeight / 2 };
+  }
+}
+
+/**
+ * Resolve positioned images to absolute coordinates
+ */
+function resolvePositionedImages(
+  images: PositionedImage[],
+  layoutedNodes: LayoutedNode[],
+  canvasWidth: number,
+  canvasHeight: number
+): LayoutedImage[] {
+  const result: LayoutedImage[] = [];
+  const defaultSize = 50;
+
+  // Build node lookup by label
+  const nodeByLabel = new Map<string, LayoutedNode>();
+  for (const node of layoutedNodes) {
+    nodeByLabel.set(node.label, node);
+  }
+
+  for (const image of images) {
+    const width = image.width || defaultSize;
+    const height = image.height || defaultSize;
+
+    if (image.position.type === 'absolute') {
+      result.push({
+        id: image.id,
+        src: image.src,
+        x: image.position.x,
+        y: image.position.y,
+        width,
+        height,
+      });
+    } else if (image.position.type === 'near') {
+      const node = nodeByLabel.get(image.position.nodeLabel);
+      if (node) {
+        const offset = getAnchorOffset(
+          image.position.anchor,
+          node.width,
+          node.height,
+          width,
+          height
+        );
+        result.push({
+          id: image.id,
+          src: image.src,
+          x: node.x + offset.x,
+          y: node.y + offset.y,
+          width,
+          height,
+        });
+      } else {
+        // Node not found, place at origin
+        console.warn(`Node "${image.position.nodeLabel}" not found for positioned image`);
+        result.push({
+          id: image.id,
+          src: image.src,
+          x: 0,
+          y: 0,
+          width,
+          height,
+        });
+      }
+    }
+  }
+
+  return result;
 }

--- a/src/layout/elk-layout.ts
+++ b/src/layout/elk-layout.ts
@@ -305,8 +305,8 @@ function getAnchorOffset(
 function resolvePositionedImages(
   images: PositionedImage[],
   layoutedNodes: LayoutedNode[],
-  canvasWidth: number,
-  canvasHeight: number
+  _canvasWidth: number,
+  _canvasHeight: number
 ): LayoutedImage[] {
   const result: LayoutedImage[] = [];
   const defaultSize = 50;

--- a/src/parser/dot-parser.ts
+++ b/src/parser/dot-parser.ts
@@ -77,6 +77,17 @@ function mapRankDir(rankdir: string | undefined): FlowDirection | undefined {
 }
 
 /**
+ * Check if a DOT style attribute contains a specific style value.
+ * DOT style attributes can be comma-separated (e.g., "filled,dashed").
+ * This function splits by comma and checks for exact matches to avoid
+ * false positives like "dashedline" matching "dashed".
+ */
+function hasStyleValue(styleAttr: string, value: string): boolean {
+  const styles = styleAttr.split(',').map((s) => s.trim().toLowerCase());
+  return styles.includes(value.toLowerCase());
+}
+
+/**
  * Extract node style from DOT attributes
  */
 function extractNodeStyle(node: NodeModel): NodeStyle | undefined {
@@ -97,10 +108,10 @@ function extractNodeStyle(node: NodeModel): NodeStyle | undefined {
 
   const styleAttr = node.attributes.get('style');
   if (styleAttr && typeof styleAttr === 'string') {
-    if (styleAttr.includes('dashed')) {
+    if (hasStyleValue(styleAttr, 'dashed')) {
       style.strokeStyle = 'dashed';
       hasStyle = true;
-    } else if (styleAttr.includes('dotted')) {
+    } else if (hasStyleValue(styleAttr, 'dotted')) {
       style.strokeStyle = 'dotted';
       hasStyle = true;
     }
@@ -124,10 +135,10 @@ function extractEdgeStyle(edge: EdgeModel): EdgeStyle | undefined {
 
   const styleAttr = edge.attributes.get('style');
   if (styleAttr && typeof styleAttr === 'string') {
-    if (styleAttr.includes('dashed')) {
+    if (hasStyleValue(styleAttr, 'dashed')) {
       style.strokeStyle = 'dashed';
       hasStyle = true;
-    } else if (styleAttr.includes('dotted')) {
+    } else if (hasStyleValue(styleAttr, 'dotted')) {
       style.strokeStyle = 'dotted';
       hasStyle = true;
     }

--- a/src/parser/dot-parser.ts
+++ b/src/parser/dot-parser.ts
@@ -1,0 +1,269 @@
+/**
+ * DOT/Graphviz Parser
+ *
+ * Parses DOT language syntax and converts to FlowchartGraph.
+ * Uses ts-graphviz library for parsing.
+ *
+ * Supported DOT features:
+ *   - digraph and graph declarations
+ *   - Node declarations with labels and shapes
+ *   - Edges: A -> B (directed) and A -- B (undirected)
+ *   - Edge labels: [label="text"]
+ *   - Node shapes: [shape=diamond|ellipse|box|cylinder]
+ *   - Graph direction: rankdir=TB|BT|LR|RL
+ *   - Dashed edges: [style=dashed]
+ *   - Subgraphs (flattened to regular nodes)
+ *   - Color attributes (fillcolor, color)
+ */
+
+import { fromDot, type RootGraphModel, type NodeModel, type EdgeModel, type SubgraphModel } from 'ts-graphviz';
+import { nanoid } from 'nanoid';
+import type {
+  FlowchartGraph,
+  GraphNode,
+  GraphEdge,
+  LayoutOptions,
+  NodeType,
+  FlowDirection,
+  NodeStyle,
+  EdgeStyle,
+} from '../types/dsl.js';
+import { DEFAULT_LAYOUT_OPTIONS } from '../types/dsl.js';
+
+/**
+ * Map DOT shape names to our NodeType
+ */
+function mapDotShape(dotShape: string | undefined): NodeType {
+  if (!dotShape) return 'rectangle';
+
+  const shape = dotShape.toLowerCase();
+
+  switch (shape) {
+    case 'ellipse':
+    case 'oval':
+    case 'circle':
+      return 'ellipse';
+    case 'diamond':
+      return 'diamond';
+    case 'cylinder':
+    case 'record':
+    case 'mrecord':
+      return 'database';
+    case 'box':
+    case 'rect':
+    case 'rectangle':
+    case 'square':
+    default:
+      return 'rectangle';
+  }
+}
+
+/**
+ * Map DOT rankdir to our FlowDirection
+ */
+function mapRankDir(rankdir: string | undefined): FlowDirection | undefined {
+  if (!rankdir) return undefined;
+
+  const dir = rankdir.toUpperCase();
+  if (dir === 'TB' || dir === 'BT' || dir === 'LR' || dir === 'RL') {
+    return dir as FlowDirection;
+  }
+  return undefined;
+}
+
+/**
+ * Extract node style from DOT attributes
+ */
+function extractNodeStyle(node: NodeModel): NodeStyle | undefined {
+  const style: NodeStyle = {};
+  let hasStyle = false;
+
+  const fillcolor = node.attributes.get('fillcolor');
+  if (fillcolor && typeof fillcolor === 'string') {
+    style.backgroundColor = fillcolor;
+    hasStyle = true;
+  }
+
+  const color = node.attributes.get('color');
+  if (color && typeof color === 'string') {
+    style.strokeColor = color;
+    hasStyle = true;
+  }
+
+  const styleAttr = node.attributes.get('style');
+  if (styleAttr && typeof styleAttr === 'string') {
+    if (styleAttr.includes('dashed')) {
+      style.strokeStyle = 'dashed';
+      hasStyle = true;
+    } else if (styleAttr.includes('dotted')) {
+      style.strokeStyle = 'dotted';
+      hasStyle = true;
+    }
+  }
+
+  return hasStyle ? style : undefined;
+}
+
+/**
+ * Extract edge style from DOT attributes
+ */
+function extractEdgeStyle(edge: EdgeModel): EdgeStyle | undefined {
+  const style: EdgeStyle = {};
+  let hasStyle = false;
+
+  const color = edge.attributes.get('color');
+  if (color && typeof color === 'string') {
+    style.strokeColor = color;
+    hasStyle = true;
+  }
+
+  const styleAttr = edge.attributes.get('style');
+  if (styleAttr && typeof styleAttr === 'string') {
+    if (styleAttr.includes('dashed')) {
+      style.strokeStyle = 'dashed';
+      hasStyle = true;
+    } else if (styleAttr.includes('dotted')) {
+      style.strokeStyle = 'dotted';
+      hasStyle = true;
+    }
+  }
+
+  return hasStyle ? style : undefined;
+}
+
+/**
+ * Get the node ID from an edge target (handles NodeModel and ForwardRefNode)
+ */
+function getNodeIdFromTarget(target: unknown): string | null {
+  if (!target) return null;
+
+  // Handle NodeModel
+  if (typeof target === 'object' && 'id' in target && typeof (target as { id: unknown }).id === 'string') {
+    return (target as { id: string }).id;
+  }
+
+  return null;
+}
+
+/**
+ * Recursively collect all nodes from a graph and its subgraphs
+ */
+function collectNodes(
+  graph: RootGraphModel | SubgraphModel,
+  nodeMap: Map<string, GraphNode>
+): void {
+  // Process nodes in this graph
+  for (const node of graph.nodes) {
+    if (nodeMap.has(node.id)) continue;
+
+    const label = node.attributes.get('label');
+    const shape = node.attributes.get('shape');
+    const nodeStyle = extractNodeStyle(node);
+
+    nodeMap.set(node.id, {
+      id: nanoid(10),
+      type: mapDotShape(typeof shape === 'string' ? shape : undefined),
+      label: typeof label === 'string' ? label : node.id,
+      style: nodeStyle,
+    });
+  }
+
+  // Recursively process subgraphs
+  for (const subgraph of graph.subgraphs) {
+    collectNodes(subgraph, nodeMap);
+  }
+}
+
+/**
+ * Recursively collect all edges from a graph and its subgraphs
+ */
+function collectEdges(
+  graph: RootGraphModel | SubgraphModel,
+  nodeMap: Map<string, GraphNode>,
+  edges: GraphEdge[]
+): void {
+  // Process edges in this graph
+  for (const edge of graph.edges) {
+    const targets = edge.targets;
+    if (!targets || targets.length < 2) continue;
+
+    // Process edge chain (A -> B -> C becomes A->B and B->C)
+    for (let i = 0; i < targets.length - 1; i++) {
+      const sourceId = getNodeIdFromTarget(targets[i]);
+      const targetId = getNodeIdFromTarget(targets[i + 1]);
+
+      if (!sourceId || !targetId) continue;
+
+      const sourceNode = nodeMap.get(sourceId);
+      const targetNode = nodeMap.get(targetId);
+
+      if (!sourceNode || !targetNode) continue;
+
+      const label = edge.attributes.get('label');
+      const edgeStyle = extractEdgeStyle(edge);
+
+      edges.push({
+        id: nanoid(10),
+        source: sourceNode.id,
+        target: targetNode.id,
+        label: typeof label === 'string' ? label : undefined,
+        style: edgeStyle,
+      });
+    }
+  }
+
+  // Recursively process subgraphs
+  for (const subgraph of graph.subgraphs) {
+    collectEdges(subgraph, nodeMap, edges);
+  }
+}
+
+/**
+ * Parse DOT string into a FlowchartGraph
+ */
+export function parseDOT(input: string): FlowchartGraph {
+  let rootGraph: RootGraphModel;
+
+  try {
+    rootGraph = fromDot(input);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid DOT syntax: ${message}`);
+  }
+
+  const options: LayoutOptions = { ...DEFAULT_LAYOUT_OPTIONS };
+
+  // Extract graph-level attributes
+  const rankdir = rootGraph.attributes.graph.get('rankdir');
+  const direction = mapRankDir(typeof rankdir === 'string' ? rankdir : undefined);
+  if (direction) {
+    options.direction = direction;
+  }
+
+  const nodesep = rootGraph.attributes.graph.get('nodesep');
+  if (typeof nodesep === 'number') {
+    // nodesep is in inches, convert to approximate pixels (72 dpi)
+    options.nodeSpacing = Math.round(nodesep * 72);
+  }
+
+  const ranksep = rootGraph.attributes.graph.get('ranksep');
+  if (typeof ranksep === 'number') {
+    // ranksep is in inches, convert to approximate pixels (72 dpi)
+    options.rankSpacing = Math.round(ranksep * 72);
+  }
+
+  // Collect all nodes (including from subgraphs)
+  const nodeMap = new Map<string, GraphNode>();
+  collectNodes(rootGraph, nodeMap);
+
+  // Collect all edges (including from subgraphs)
+  const edges: GraphEdge[] = [];
+  collectEdges(rootGraph, nodeMap, edges);
+
+  return {
+    nodes: Array.from(nodeMap.values()),
+    edges,
+    options,
+  };
+}
+

--- a/src/parser/dsl-parser.ts
+++ b/src/parser/dsl-parser.ts
@@ -126,10 +126,10 @@ function tokenize(input: string): Token[] {
         directive += input[i];
         i++;
       }
-      // Get directive value
+      // Get directive value (stop at newline, comment, or another @)
       while (i < len && (input[i] === ' ' || input[i] === '\t')) i++;
       let value = '';
-      while (i < len && input[i] !== '\n' && input[i] !== '#') {
+      while (i < len && input[i] !== '\n' && input[i] !== '#' && input[i] !== '@') {
         value += input[i];
         i++;
       }

--- a/src/parser/dsl-parser.ts
+++ b/src/parser/dsl-parser.ts
@@ -6,11 +6,21 @@
  *   {Label}        - Diamond (decision)
  *   (Label)        - Ellipse (start/end)
  *   [[Label]]      - Database
+ *   ![path]        - Image element
+ *   ![path](WxH)   - Image with dimensions
  *   A -> B         - Connection
  *   A -> "label" -> B  - Labeled connection
  *   A --> B        - Dashed connection
+ *
+ * Directives:
  *   @direction TB  - Set flow direction (TB, BT, LR, RL)
  *   @spacing N     - Set node spacing
+ *   @image path at X,Y           - Position image at absolute coordinates
+ *   @image path near (NodeLabel) - Position image near a node
+ *   @decorate path anchor        - Attach decoration to preceding node
+ *   @sticker name [at X,Y]       - Add sticker from library
+ *   @library path                - Set custom sticker library path
+ *   @scatter path count:N        - Scatter images across canvas
  */
 
 import { nanoid } from 'nanoid';
@@ -20,14 +30,25 @@ import type {
   GraphEdge,
   LayoutOptions,
   NodeType,
+  PositionedImage,
+  ScatterConfig,
+  NodeDecoration,
+  DecorationAnchor,
+  ImageSource,
 } from '../types/dsl.js';
 import { DEFAULT_LAYOUT_OPTIONS } from '../types/dsl.js';
 
 interface Token {
-  type: 'node' | 'arrow' | 'label' | 'directive' | 'newline';
+  type: 'node' | 'arrow' | 'label' | 'directive' | 'newline' | 'image' | 'decorate';
   value: string;
   nodeType?: NodeType;
   dashed?: boolean;
+  // Image-specific properties
+  imageSrc?: string;
+  imageWidth?: number;
+  imageHeight?: number;
+  // Decoration-specific properties
+  decorationAnchor?: DecorationAnchor;
 }
 
 /**
@@ -58,7 +79,46 @@ function tokenize(input: string): Token[] {
       continue;
     }
 
-    // Directive (@direction, @spacing)
+    // Image ![path] or ![path](WxH)
+    if (input[i] === '!' && input[i + 1] === '[') {
+      i += 2; // skip ![
+      let src = '';
+      while (i < len && input[i] !== ']') {
+        src += input[i];
+        i++;
+      }
+      i++; // skip ]
+
+      let width: number | undefined;
+      let height: number | undefined;
+
+      // Check for optional dimensions (WxH)
+      if (i < len && input[i] === '(') {
+        i++; // skip (
+        let dims = '';
+        while (i < len && input[i] !== ')') {
+          dims += input[i];
+          i++;
+        }
+        i++; // skip )
+        const match = dims.match(/^(\d+)\s*[xX]\s*(\d+)$/);
+        if (match) {
+          width = parseInt(match[1], 10);
+          height = parseInt(match[2], 10);
+        }
+      }
+
+      tokens.push({
+        type: 'image',
+        value: src.trim(),
+        imageSrc: src.trim(),
+        imageWidth: width,
+        imageHeight: height,
+      });
+      continue;
+    }
+
+    // Directive (@direction, @spacing, @image, @decorate, @sticker, @library, @scatter)
     if (input[i] === '@') {
       let directive = '';
       i++; // skip @
@@ -73,7 +133,22 @@ function tokenize(input: string): Token[] {
         value += input[i];
         i++;
       }
-      tokens.push({ type: 'directive', value: `${directive} ${value.trim()}` });
+
+      // Handle @decorate as a special token type (attaches to preceding node)
+      if (directive === 'decorate') {
+        // Parse: @decorate path anchor
+        const parts = value.trim().split(/\s+/);
+        const src = parts[0] || '';
+        const anchor = (parts[1] || 'top-right') as DecorationAnchor;
+        tokens.push({
+          type: 'decorate',
+          value: src,
+          imageSrc: src,
+          decorationAnchor: anchor,
+        });
+      } else {
+        tokens.push({ type: 'directive', value: `${directive} ${value.trim()}` });
+      }
       continue;
     }
 
@@ -175,6 +250,68 @@ function tokenize(input: string): Token[] {
 }
 
 /**
+ * Parse @image directive value
+ * Formats:
+ *   @image path at X,Y
+ *   @image path near (NodeLabel)
+ *   @image path near (NodeLabel) anchor
+ */
+function parseImageDirective(value: string): PositionedImage | null {
+  // Match: path at X,Y
+  const atMatch = value.match(/^(.+?)\s+at\s+(\d+)\s*,\s*(\d+)$/i);
+  if (atMatch) {
+    return {
+      id: nanoid(10),
+      src: atMatch[1].trim(),
+      position: {
+        type: 'absolute',
+        x: parseInt(atMatch[2], 10),
+        y: parseInt(atMatch[3], 10),
+      },
+    };
+  }
+
+  // Match: path near (NodeLabel) [anchor]
+  const nearMatch = value.match(/^(.+?)\s+near\s+\(([^)]+)\)(?:\s+(\S+))?$/i);
+  if (nearMatch) {
+    return {
+      id: nanoid(10),
+      src: nearMatch[1].trim(),
+      position: {
+        type: 'near',
+        nodeLabel: nearMatch[2].trim(),
+        anchor: (nearMatch[3] as DecorationAnchor) || undefined,
+      },
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Parse @scatter directive value
+ * Format: @scatter path count:N [width:W] [height:H]
+ */
+function parseScatterDirective(value: string): ScatterConfig | null {
+  const parts = value.trim().split(/\s+/);
+  if (parts.length < 2) return null;
+
+  const src = parts[0];
+  let count = 10; // default
+  let width: number | undefined;
+  let height: number | undefined;
+
+  for (let i = 1; i < parts.length; i++) {
+    const [key, val] = parts[i].split(':');
+    if (key === 'count' && val) count = parseInt(val, 10);
+    if (key === 'width' && val) width = parseInt(val, 10);
+    if (key === 'height' && val) height = parseInt(val, 10);
+  }
+
+  return { src, count, width, height };
+}
+
+/**
  * Parse tokens into a FlowchartGraph
  */
 export function parseDSL(input: string): FlowchartGraph {
@@ -183,17 +320,28 @@ export function parseDSL(input: string): FlowchartGraph {
   const nodes: Map<string, GraphNode> = new Map();
   const edges: GraphEdge[] = [];
   const options: LayoutOptions = { ...DEFAULT_LAYOUT_OPTIONS };
+  const images: PositionedImage[] = [];
+  const scatter: ScatterConfig[] = [];
+  let library: string | undefined;
 
   // Helper to get or create node by label
-  function getOrCreateNode(label: string, type: NodeType): GraphNode {
+  function getOrCreateNode(
+    label: string,
+    type: NodeType,
+    imageData?: ImageSource
+  ): GraphNode {
     // Use label as key for deduplication
     const key = `${type}:${label}`;
     if (!nodes.has(key)) {
-      nodes.set(key, {
+      const node: GraphNode = {
         id: nanoid(10),
         type,
         label,
-      });
+      };
+      if (imageData) {
+        node.image = imageData;
+      }
+      nodes.set(key, node);
     }
     return nodes.get(key)!;
   }
@@ -228,6 +376,75 @@ export function parseDSL(input: string): FlowchartGraph {
         if (!isNaN(spacing)) {
           options.nodeSpacing = spacing;
         }
+      } else if (directive === 'image') {
+        const img = parseImageDirective(value);
+        if (img) images.push(img);
+      } else if (directive === 'scatter') {
+        const cfg = parseScatterDirective(value);
+        if (cfg) scatter.push(cfg);
+      } else if (directive === 'library') {
+        library = value.trim();
+      } else if (directive === 'sticker') {
+        // Stickers are resolved later using the library path
+        // For now, treat as positioned image with sticker: prefix
+        const parts = value.trim().split(/\s+/);
+        const stickerName = parts[0];
+        if (stickerName) {
+          // Check for positioning (at or near)
+          const restValue = parts.slice(1).join(' ');
+          if (restValue.includes('at') || restValue.includes('near')) {
+            const img = parseImageDirective(`sticker:${stickerName} ${restValue}`);
+            if (img) images.push(img);
+          } else {
+            // Standalone sticker - will be placed at default position
+            images.push({
+              id: nanoid(10),
+              src: `sticker:${stickerName}`,
+              position: { type: 'absolute', x: 0, y: 0 }, // Will be resolved later
+            });
+          }
+        }
+      }
+      i++;
+      continue;
+    }
+
+    if (token.type === 'image') {
+      // Create an image node
+      const imageData: ImageSource = {
+        src: token.imageSrc!,
+        width: token.imageWidth,
+        height: token.imageHeight,
+      };
+      const node = getOrCreateNode(token.value, 'image', imageData);
+
+      if (lastNode) {
+        edges.push({
+          id: nanoid(10),
+          source: lastNode.id,
+          target: node.id,
+          label: pendingLabel || undefined,
+          style: pendingDashed ? { strokeStyle: 'dashed' } : undefined,
+        });
+        pendingLabel = null;
+        pendingDashed = false;
+      }
+
+      lastNode = node;
+      i++;
+      continue;
+    }
+
+    if (token.type === 'decorate') {
+      // Attach decoration to the last node
+      if (lastNode) {
+        if (!lastNode.decorations) {
+          lastNode.decorations = [];
+        }
+        lastNode.decorations.push({
+          src: token.imageSrc!,
+          anchor: token.decorationAnchor || 'top-right',
+        });
       }
       i++;
       continue;
@@ -269,11 +486,17 @@ export function parseDSL(input: string): FlowchartGraph {
     i++;
   }
 
-  return {
+  const result: FlowchartGraph = {
     nodes: Array.from(nodes.values()),
     edges,
     options,
   };
+
+  if (images.length > 0) result.images = images;
+  if (scatter.length > 0) result.scatter = scatter;
+  if (library) result.library = library;
+
+  return result;
 }
 
 // Re-export DEFAULT_LAYOUT_OPTIONS

--- a/src/parser/dsl-parser.ts
+++ b/src/parser/dsl-parser.ts
@@ -32,7 +32,6 @@ import type {
   NodeType,
   PositionedImage,
   ScatterConfig,
-  NodeDecoration,
   DecorationAnchor,
   ImageSource,
 } from '../types/dsl.js';

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -4,3 +4,4 @@
 
 export { parseDSL } from './dsl-parser.js';
 export { parseJSON, parseJSONString } from './json-parser.js';
+export { parseDOT } from './dot-parser.js';

--- a/src/types/dsl.ts
+++ b/src/types/dsl.ts
@@ -2,7 +2,7 @@
  * Flowchart DSL Type Definitions
  */
 
-export type NodeType = 'rectangle' | 'diamond' | 'ellipse' | 'database';
+export type NodeType = 'rectangle' | 'diamond' | 'ellipse' | 'database' | 'image';
 
 export type FlowDirection = 'TB' | 'BT' | 'LR' | 'RL';
 
@@ -42,6 +42,38 @@ export interface EdgeStyle {
 }
 
 /**
+ * Image source configuration
+ */
+export interface ImageSource {
+  src: string; // File path or URL
+  width?: number; // Explicit width (optional)
+  height?: number; // Explicit height (optional)
+}
+
+/**
+ * Decoration position anchors
+ */
+export type DecorationAnchor =
+  | 'top'
+  | 'bottom'
+  | 'left'
+  | 'right'
+  | 'top-left'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-right';
+
+/**
+ * Decoration attached to a node
+ */
+export interface NodeDecoration {
+  src: string;
+  anchor: DecorationAnchor;
+  width?: number;
+  height?: number;
+}
+
+/**
  * A node in the flowchart graph
  */
 export interface GraphNode {
@@ -49,6 +81,8 @@ export interface GraphNode {
   type: NodeType;
   label: string;
   style?: NodeStyle;
+  image?: ImageSource; // For image nodes
+  decorations?: NodeDecoration[]; // Decorations attached to this node
 }
 
 /**
@@ -74,12 +108,38 @@ export interface LayoutOptions {
 }
 
 /**
+ * Positioned image (decoration placed at absolute or relative position)
+ */
+export interface PositionedImage {
+  id: string;
+  src: string;
+  position:
+    | { type: 'absolute'; x: number; y: number }
+    | { type: 'near'; nodeLabel: string; anchor?: DecorationAnchor };
+  width?: number;
+  height?: number;
+}
+
+/**
+ * Scatter configuration for distributing images across the canvas
+ */
+export interface ScatterConfig {
+  src: string;
+  count: number;
+  width?: number;
+  height?: number;
+}
+
+/**
  * Complete flowchart graph representation
  */
 export interface FlowchartGraph {
   nodes: GraphNode[];
   edges: GraphEdge[];
   options: LayoutOptions;
+  images?: PositionedImage[]; // @image directives
+  scatter?: ScatterConfig[]; // @scatter directives
+  library?: string; // @library path
 }
 
 /**
@@ -132,6 +192,18 @@ export interface LayoutedEdge extends GraphEdge {
 }
 
 /**
+ * Layouted positioned image with resolved coordinates
+ */
+export interface LayoutedImage {
+  id: string;
+  src: string;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/**
  * Layouted flowchart graph
  */
 export interface LayoutedGraph {
@@ -140,4 +212,7 @@ export interface LayoutedGraph {
   options: LayoutOptions;
   width: number;
   height: number;
+  images?: LayoutedImage[]; // Resolved positioned images
+  scatter?: ScatterConfig[]; // Scatter configs for post-layout generation
+  library?: string; // Library path
 }

--- a/src/types/excalidraw.ts
+++ b/src/types/excalidraw.ts
@@ -10,7 +10,8 @@ export type ExcalidrawElementType =
   | 'text'
   | 'arrow'
   | 'line'
-  | 'freedraw';
+  | 'freedraw'
+  | 'image';
 
 export type ExcalidrawFillStyle = 'solid' | 'hachure' | 'cross-hatch';
 
@@ -143,6 +144,16 @@ export interface ExcalidrawLine extends ExcalidrawElementBase {
 }
 
 /**
+ * Image element
+ */
+export interface ExcalidrawImage extends ExcalidrawElementBase {
+  type: 'image';
+  fileId: string;
+  status: 'pending' | 'saved' | 'error';
+  scale: [number, number];
+}
+
+/**
  * Union type for all Excalidraw elements
  */
 export type ExcalidrawElement =
@@ -151,7 +162,19 @@ export type ExcalidrawElement =
   | ExcalidrawEllipse
   | ExcalidrawText
   | ExcalidrawArrow
-  | ExcalidrawLine;
+  | ExcalidrawLine
+  | ExcalidrawImage;
+
+/**
+ * File data for embedded images
+ */
+export interface ExcalidrawFileData {
+  mimeType: string;
+  id: string;
+  dataURL: string; // data:image/...;base64,... or URL
+  created: number;
+  lastRetrieved?: number;
+}
 
 /**
  * Application state for the canvas
@@ -173,7 +196,7 @@ export interface ExcalidrawFile {
   source: string;
   elements: ExcalidrawElement[];
   appState: ExcalidrawAppState;
-  files: Record<string, unknown>;
+  files: Record<string, ExcalidrawFileData>;
 }
 
 /**

--- a/tests/unit/parser/dot-parser.test.ts
+++ b/tests/unit/parser/dot-parser.test.ts
@@ -33,7 +33,7 @@ describe('DOT Parser', () => {
     });
 
     it('should parse circle nodes as ellipse', () => {
-      // Note: 'Node' is a reserved word in DOT, so we use 'MyNode'
+      // Note: 'node' (case-insensitive) is a DOT keyword for setting default node attributes
       const result = parseDOT('digraph { MyNode [shape=circle]; }');
       expect(result.nodes[0].type).toBe('ellipse');
     });
@@ -294,8 +294,10 @@ describe('DOT Parser', () => {
 
     it('should parse strict digraph', () => {
       const result = parseDOT('strict digraph { A -> B; A -> B; }');
-      // In strict mode, duplicate edges are merged
       expect(result.nodes).toHaveLength(2);
+      // In strict mode, duplicate edges should be merged by ts-graphviz
+      // The edge count depends on how ts-graphviz handles strict mode
+      expect(result.edges.length).toBeGreaterThanOrEqual(1);
     });
   });
 });

--- a/tests/unit/parser/dot-parser.test.ts
+++ b/tests/unit/parser/dot-parser.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect } from 'vitest';
+import { parseDOT } from '../../../src/parser/dot-parser.js';
+
+describe('DOT Parser', () => {
+  describe('node parsing', () => {
+    it('should parse nodes from a simple digraph', () => {
+      const result = parseDOT('digraph { A; B; C; }');
+      expect(result.nodes).toHaveLength(3);
+      expect(result.nodes.map((n) => n.label).sort()).toEqual(['A', 'B', 'C']);
+    });
+
+    it('should parse rectangle nodes (default shape)', () => {
+      const result = parseDOT('digraph { A [shape=box]; }');
+      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes[0].type).toBe('rectangle');
+    });
+
+    it('should parse rectangle nodes with rect shape', () => {
+      const result = parseDOT('digraph { A [shape=rect]; }');
+      expect(result.nodes[0].type).toBe('rectangle');
+    });
+
+    it('should parse ellipse nodes', () => {
+      const result = parseDOT('digraph { Start [shape=ellipse]; }');
+      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes[0].type).toBe('ellipse');
+      expect(result.nodes[0].label).toBe('Start');
+    });
+
+    it('should parse oval nodes as ellipse', () => {
+      const result = parseDOT('digraph { End [shape=oval]; }');
+      expect(result.nodes[0].type).toBe('ellipse');
+    });
+
+    it('should parse circle nodes as ellipse', () => {
+      // Note: 'Node' is a reserved word in DOT, so we use 'MyNode'
+      const result = parseDOT('digraph { MyNode [shape=circle]; }');
+      expect(result.nodes[0].type).toBe('ellipse');
+    });
+
+    it('should parse diamond nodes', () => {
+      const result = parseDOT('digraph { Decision [shape=diamond]; }');
+      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes[0].type).toBe('diamond');
+    });
+
+    it('should parse cylinder nodes as database', () => {
+      const result = parseDOT('digraph { DB [shape=cylinder]; }');
+      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes[0].type).toBe('database');
+    });
+
+    it('should parse record nodes as database', () => {
+      const result = parseDOT('digraph { Storage [shape=record]; }');
+      expect(result.nodes[0].type).toBe('database');
+    });
+
+    it('should use label attribute when provided', () => {
+      const result = parseDOT('digraph { A [label="Process Step"]; }');
+      expect(result.nodes[0].label).toBe('Process Step');
+    });
+
+    it('should use node ID as label when no label attribute', () => {
+      const result = parseDOT('digraph { ProcessStep; }');
+      expect(result.nodes[0].label).toBe('ProcessStep');
+    });
+
+    it('should handle quoted node IDs', () => {
+      const result = parseDOT('digraph { "Node With Spaces"; }');
+      expect(result.nodes[0].label).toBe('Node With Spaces');
+    });
+  });
+
+  describe('edge parsing', () => {
+    it('should parse simple directed edges', () => {
+      const result = parseDOT('digraph { A -> B; }');
+      expect(result.nodes).toHaveLength(2);
+      expect(result.edges).toHaveLength(1);
+
+      const sourceNode = result.nodes.find((n) => n.label === 'A');
+      const targetNode = result.nodes.find((n) => n.label === 'B');
+      expect(result.edges[0].source).toBe(sourceNode?.id);
+      expect(result.edges[0].target).toBe(targetNode?.id);
+    });
+
+    it('should parse edge chains', () => {
+      const result = parseDOT('digraph { A -> B -> C; }');
+      expect(result.nodes).toHaveLength(3);
+      expect(result.edges).toHaveLength(2);
+    });
+
+    it('should parse multiple edges', () => {
+      const result = parseDOT('digraph { A -> B; B -> C; C -> A; }');
+      expect(result.edges).toHaveLength(3);
+    });
+
+    it('should parse labeled edges', () => {
+      const result = parseDOT('digraph { A -> B [label="yes"]; }');
+      expect(result.edges[0].label).toBe('yes');
+    });
+
+    it('should parse dashed edges', () => {
+      const result = parseDOT('digraph { A -> B [style=dashed]; }');
+      expect(result.edges[0].style?.strokeStyle).toBe('dashed');
+    });
+
+    it('should parse dotted edges', () => {
+      const result = parseDOT('digraph { A -> B [style=dotted]; }');
+      expect(result.edges[0].style?.strokeStyle).toBe('dotted');
+    });
+
+    it('should parse edge color', () => {
+      const result = parseDOT('digraph { A -> B [color=red]; }');
+      expect(result.edges[0].style?.strokeColor).toBe('red');
+    });
+
+    it('should parse undirected graph edges', () => {
+      const result = parseDOT('graph { A -- B; }');
+      expect(result.nodes).toHaveLength(2);
+      expect(result.edges).toHaveLength(1);
+    });
+  });
+
+  describe('direction/layout options', () => {
+    it('should parse rankdir TB', () => {
+      const result = parseDOT('digraph { rankdir=TB; A -> B; }');
+      expect(result.options.direction).toBe('TB');
+    });
+
+    it('should parse rankdir LR', () => {
+      const result = parseDOT('digraph { rankdir=LR; A -> B; }');
+      expect(result.options.direction).toBe('LR');
+    });
+
+    it('should parse rankdir BT', () => {
+      const result = parseDOT('digraph { rankdir=BT; A -> B; }');
+      expect(result.options.direction).toBe('BT');
+    });
+
+    it('should parse rankdir RL', () => {
+      const result = parseDOT('digraph { rankdir=RL; A -> B; }');
+      expect(result.options.direction).toBe('RL');
+    });
+
+    it('should default to TB when no rankdir specified', () => {
+      const result = parseDOT('digraph { A -> B; }');
+      expect(result.options.direction).toBe('TB');
+    });
+  });
+
+  describe('node styles', () => {
+    it('should parse fillcolor attribute', () => {
+      const result = parseDOT('digraph { A [fillcolor=lightblue]; }');
+      expect(result.nodes[0].style?.backgroundColor).toBe('lightblue');
+    });
+
+    it('should parse color attribute as stroke color', () => {
+      const result = parseDOT('digraph { A [color=red]; }');
+      expect(result.nodes[0].style?.strokeColor).toBe('red');
+    });
+
+    it('should parse dashed node style', () => {
+      const result = parseDOT('digraph { A [style=dashed]; }');
+      expect(result.nodes[0].style?.strokeStyle).toBe('dashed');
+    });
+  });
+
+  describe('subgraph handling', () => {
+    it('should flatten subgraph nodes to main graph', () => {
+      const result = parseDOT(`
+        digraph {
+          subgraph cluster_0 {
+            A; B;
+          }
+          C;
+        }
+      `);
+      expect(result.nodes).toHaveLength(3);
+      expect(result.nodes.map((n) => n.label).sort()).toEqual(['A', 'B', 'C']);
+    });
+
+    it('should preserve edges within subgraphs', () => {
+      const result = parseDOT(`
+        digraph {
+          subgraph cluster_0 {
+            A -> B;
+          }
+          B -> C;
+        }
+      `);
+      expect(result.edges).toHaveLength(2);
+    });
+
+    it('should handle nested subgraphs', () => {
+      const result = parseDOT(`
+        digraph {
+          subgraph cluster_outer {
+            subgraph cluster_inner {
+              A;
+            }
+            B;
+          }
+          C;
+        }
+      `);
+      expect(result.nodes).toHaveLength(3);
+    });
+  });
+
+  describe('complex flowcharts', () => {
+    it('should parse a decision tree flowchart', () => {
+      const dot = `
+        digraph {
+          rankdir=TB;
+          
+          Start [shape=ellipse];
+          Process [shape=box];
+          Decision [shape=diamond];
+          End [shape=ellipse];
+          
+          Start -> Process;
+          Process -> Decision;
+          Decision -> End [label="yes"];
+          Decision -> Process [label="no"];
+        }
+      `;
+      const result = parseDOT(dot);
+
+      expect(result.nodes).toHaveLength(4);
+      expect(result.edges).toHaveLength(4);
+
+      const startNode = result.nodes.find((n) => n.label === 'Start');
+      const decisionNode = result.nodes.find((n) => n.label === 'Decision');
+      expect(startNode?.type).toBe('ellipse');
+      expect(decisionNode?.type).toBe('diamond');
+
+      const yesEdge = result.edges.find((e) => e.label === 'yes');
+      const noEdge = result.edges.find((e) => e.label === 'no');
+      expect(yesEdge).toBeDefined();
+      expect(noEdge).toBeDefined();
+    });
+
+    it('should parse a login flow from the issue example', () => {
+      const dot = `
+        digraph {
+          Start -> Process -> Decision;
+          Decision -> End [label="yes"];
+          Decision -> Process [label="no"];
+          
+          Start [shape=ellipse];
+          Decision [shape=diamond];
+          End [shape=ellipse];
+        }
+      `;
+      const result = parseDOT(dot);
+
+      expect(result.nodes.length).toBeGreaterThanOrEqual(4);
+      expect(result.edges.length).toBeGreaterThanOrEqual(4);
+    });
+
+    it('should deduplicate nodes referenced multiple times', () => {
+      const result = parseDOT('digraph { A -> B; B -> C; A -> C; }');
+      expect(result.nodes).toHaveLength(3);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw on invalid DOT syntax', () => {
+      expect(() => parseDOT('not valid dot')).toThrow('Invalid DOT syntax');
+    });
+
+    it('should throw on unclosed braces', () => {
+      expect(() => parseDOT('digraph { A -> B')).toThrow();
+    });
+
+    it('should handle empty digraph', () => {
+      const result = parseDOT('digraph {}');
+      expect(result.nodes).toHaveLength(0);
+      expect(result.edges).toHaveLength(0);
+    });
+
+    it('should handle digraph with only whitespace', () => {
+      const result = parseDOT('digraph {   }');
+      expect(result.nodes).toHaveLength(0);
+    });
+  });
+
+  describe('named graphs', () => {
+    it('should parse named digraph', () => {
+      const result = parseDOT('digraph MyGraph { A -> B; }');
+      expect(result.nodes).toHaveLength(2);
+      expect(result.edges).toHaveLength(1);
+    });
+
+    it('should parse strict digraph', () => {
+      const result = parseDOT('strict digraph { A -> B; A -> B; }');
+      // In strict mode, duplicate edges are merged
+      expect(result.nodes).toHaveLength(2);
+    });
+  });
+});
+

--- a/tests/unit/parser/dsl-parser.test.ts
+++ b/tests/unit/parser/dsl-parser.test.ts
@@ -89,4 +89,111 @@ describe('DSL Parser', () => {
       expect(bNodes).toHaveLength(1);
     });
   });
+
+  describe('image parsing', () => {
+    it('should parse basic image nodes', () => {
+      const result = parseDSL('![logo.png]');
+      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes[0].type).toBe('image');
+      expect(result.nodes[0].label).toBe('logo.png');
+      expect(result.nodes[0].image?.src).toBe('logo.png');
+    });
+
+    it('should parse image nodes with dimensions', () => {
+      const result = parseDSL('![logo.png](200x100)');
+      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes[0].type).toBe('image');
+      expect(result.nodes[0].image?.width).toBe(200);
+      expect(result.nodes[0].image?.height).toBe(100);
+    });
+
+    it('should parse images in flowcharts', () => {
+      const result = parseDSL('(Start) -> ![icon.png] -> [Process]');
+      expect(result.nodes).toHaveLength(3);
+      expect(result.nodes[1].type).toBe('image');
+      expect(result.edges).toHaveLength(2);
+    });
+
+    it('should parse URL images', () => {
+      const result = parseDSL('![https://example.com/image.png]');
+      expect(result.nodes[0].image?.src).toBe('https://example.com/image.png');
+    });
+  });
+
+  describe('image directive parsing', () => {
+    it('should parse @image at directive', () => {
+      const result = parseDSL('@image icon.png at 100,200');
+      expect(result.images).toHaveLength(1);
+      expect(result.images![0].src).toBe('icon.png');
+      expect(result.images![0].position).toEqual({ type: 'absolute', x: 100, y: 200 });
+    });
+
+    it('should parse @image near directive', () => {
+      const result = parseDSL('@image icon.png near (Start)');
+      expect(result.images).toHaveLength(1);
+      expect(result.images![0].position).toEqual({
+        type: 'near',
+        nodeLabel: 'Start',
+        anchor: undefined,
+      });
+    });
+
+    it('should parse @image near with anchor', () => {
+      const result = parseDSL('@image icon.png near (Start) top-left');
+      expect(result.images![0].position).toEqual({
+        type: 'near',
+        nodeLabel: 'Start',
+        anchor: 'top-left',
+      });
+    });
+  });
+
+  describe('decoration parsing', () => {
+    it('should parse @decorate directive', () => {
+      const result = parseDSL('(Start) @decorate holly.png top-left');
+      expect(result.nodes).toHaveLength(1);
+      expect(result.nodes[0].decorations).toHaveLength(1);
+      expect(result.nodes[0].decorations![0].src).toBe('holly.png');
+      expect(result.nodes[0].decorations![0].anchor).toBe('top-left');
+    });
+
+    it('should parse multiple decorations', () => {
+      const result = parseDSL('(Start) @decorate a.png top-left @decorate b.png top-right');
+      expect(result.nodes[0].decorations).toHaveLength(2);
+    });
+  });
+
+  describe('sticker and library parsing', () => {
+    it('should parse @library directive', () => {
+      const result = parseDSL('@library ./stickers/');
+      expect(result.library).toBe('./stickers/');
+    });
+
+    it('should parse @sticker directive', () => {
+      const result = parseDSL('@sticker snowflake');
+      expect(result.images).toHaveLength(1);
+      expect(result.images![0].src).toBe('sticker:snowflake');
+    });
+
+    it('should parse @sticker with position', () => {
+      const result = parseDSL('@sticker snowflake at 50,50');
+      expect(result.images![0].src).toBe('sticker:snowflake');
+      expect(result.images![0].position).toEqual({ type: 'absolute', x: 50, y: 50 });
+    });
+  });
+
+  describe('scatter parsing', () => {
+    it('should parse @scatter directive', () => {
+      const result = parseDSL('@scatter snowflake.png count:20');
+      expect(result.scatter).toHaveLength(1);
+      expect(result.scatter![0].src).toBe('snowflake.png');
+      expect(result.scatter![0].count).toBe(20);
+    });
+
+    it('should parse @scatter with dimensions', () => {
+      const result = parseDSL('@scatter star.png count:10 width:30 height:30');
+      expect(result.scatter![0].width).toBe(30);
+      expect(result.scatter![0].height).toBe(30);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Merges features from #5 (Image/Asset Support) and #7 (DOT/Graphviz Support).

## Key Features
1.  **Image Support**: Embed images in diagrams using `@image` directive.
2.  **DOT Support**: Convert Graphviz `.dot` files directly to Excalidraw.

## 🧪 Testing Plan (Human Verification)

### 1. Test Image Support
**Goal**: Verify images render correctly in the output.
**Steps**:
1.  Create a file `test-image.dsl`:
    ```
    rectangle "Container"
    @image "./test.png" near "Container"
    ```
    (Ensure you have a dummy image at `./test.png`)
2.  Run: `excalidraw-cli test-image.dsl -o output.excalidraw`
3.  Load `output.excalidraw` in [excalidraw.com](https://excalidraw.com).
4.  **Expectation**: You see a rectangle and the image placed nearby.

### 2. Test DOT Support
**Goal**: Verify Graphviz conversion.
**Steps**:
1.  Create `graph.dot`:
    ```dot
    digraph G {
      A -> B [label="goes to"];
      B -> C;
      C -> A [style=dashed];
    }
    ```
2.  Run: `excalidraw-cli graph.dot -o graph.excalidraw`
3.  Load `graph.excalidraw` in [excalidraw.com](https://excalidraw.com).
4.  **Expectation**: A triangular flow diagram (A->B->C->A) with arrows, one label, and one dashed line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI and parser now accept DOT/Graphviz input (inline or .dot/.gv) with format auto-detection.
  * Image features: embed images, position/anchor decorations, stickers via libraries, and scatter multiple images.

* **Tests**
  * Added extensive unit tests for DOT parsing and image-related DSL behaviors.

* **Chores**
  * Package version bumped.

* **Documentation**
  * Added npm installation instructions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->