### PR TITLE
fix: add contents write permission for GitHub releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,8 @@ jobs:
   publish:
     needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Adds `contents: write` permission to the publish workflow
- Fixes the 403 error when creating GitHub releases

## Problem
The publish workflow was failing at the "Create GitHub Release" step with:
```
⚠️ GitHub release failed with status: 403
"Resource not accessible by integration"
```

## Solution
Added explicit `permissions: contents: write` to the publish job, which grants the `GITHUB_TOKEN` the necessary permission to create releases.

## Test plan
- [ ] Merge this PR and trigger the publish workflow
- [ ] Verify the GitHub release is created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated publish workflow permissions to enable write operations on repository contents during the publish process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->