### PR TITLE
Feature/export image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ coverage/
 # Temporary files
 *.tmp
 *.temp
+tests/tmp/

--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -1,0 +1,50 @@
+# Dependency Notes
+
+## @excalidraw/utils — pinned to `0.1.3-test32`
+
+### Why the prerelease tag?
+
+Despite its prerelease-looking version string, **`0.1.3-test32` is the npm
+`latest` dist-tag** — running `npm install @excalidraw/utils` installs this
+exact version. The Excalidraw team has been iterating on a full rewrite of the
+utils package through the `0.1.3-test*` series and has promoted `test32` as the
+current recommended release.
+
+### Why can't we use the stable `0.1.2`?
+
+`0.1.2` ships a single minified bundle (`dist/excalidraw-utils.min.js`) with a
+completely different API surface and **no `exportToSvg`** function. It also
+lacks:
+
+- Bundled font assets (TTFs for Excalifont, Virgil, etc.) required for
+  server-side text rendering
+- TypeScript type declarations
+- ESM entry points (`dist/prod/index.js`)
+
+Our image-export pipeline depends on all of these. Downgrading to `0.1.2` would
+break the `convert` command entirely.
+
+### What does `0.1.3-test32` provide?
+
+| Feature | `0.1.2` | `0.1.3-test32` |
+|---------|---------|----------------|
+| `exportToSvg()` | ✗ | ✓ |
+| Bundled TTF fonts | ✗ | ✓ (7 font files) |
+| TypeScript types | ✗ | ✓ |
+| ESM exports map | ✗ | ✓ |
+| Package size | ~430 KB | ~75 MB |
+
+### When can we move to a stable release?
+
+When the Excalidraw team publishes a stable `0.2.0` (or similar) that ships the
+same `exportToSvg` API and bundled fonts, we should upgrade. Track progress at:
+
+- <https://github.com/excalidraw/excalidraw/tree/master/packages/utils>
+- <https://www.npmjs.com/package/@excalidraw/utils?activeTab=versions>
+
+### Pinning strategy
+
+The version is pinned **without a caret** (`"0.1.3-test32"` not
+`"^0.1.3-test32"`) to prevent accidental upgrades to untested prerelease
+iterations (e.g., a hypothetical `0.1.3-test33` that could introduce breaking
+changes).

--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ echo "[A] -> [B] -> [C]" | excalidraw-cli create --stdin -o diagram.excalidraw
 # Export while creating a flowchart
 excalidraw-cli create --inline "[A] -> [B]" -o flow.excalidraw --export-as svg
 
-# Export an existing .excalidraw file to PNG
-excalidraw-cli export diagram.excalidraw -F png
+# Convert an existing .excalidraw file to PNG
+excalidraw-cli convert diagram.excalidraw --format png
 
-# Export with options
-excalidraw-cli export diagram.excalidraw -F png --export-scale 2 --dark-mode
+# Convert with options
+excalidraw-cli convert diagram.excalidraw --format png --scale 2 --dark-mode
 
-# Export SVG without background
-excalidraw-cli export diagram.excalidraw -F svg --no-export-background
+# Convert to SVG without background
+excalidraw-cli convert diagram.excalidraw --format svg --no-export-background
 ```
 
 ### DSL Syntax
@@ -131,26 +131,26 @@ excalidraw-cli create [input] [options]
 - `--dark-mode` - Export with dark mode theme
 - `--embed-scene` - Embed scene data in exported image
 - `--export-padding <n>` - Padding around content in pixels (default: 10)
-- `--export-scale <n>` - Scale factor for PNG export (default: 1)
+- `--scale <n>` - Scale factor for PNG export (default: 1)
 - `--verbose` - Verbose output
 
-#### `export`
+#### `convert`
 
-Export an existing `.excalidraw` file to PNG or SVG.
+Convert an existing `.excalidraw` file to PNG or SVG.
 
 ```bash
-excalidraw-cli export <input> [options]
+excalidraw-cli convert <input> [options]
 ```
 
 **Options:**
-- `-F, --format <format>` - **(required)** Export format: `png` or `svg`
+- `--format <format>` - **(required)** Export format: `png` or `svg`
 - `-o, --output <file>` - Output file path (default: input file with swapped extension)
 - `--export-background / --no-export-background` - Include or exclude background
 - `--background-color <color>` - Background color (default: #ffffff)
 - `--dark-mode` - Export with dark mode theme
 - `--embed-scene` - Embed scene data in exported image
 - `--export-padding <n>` - Padding around content in pixels (default: 10)
-- `--export-scale <n>` - Scale factor for PNG export (default: 1)
+- `--scale <n>` - Scale factor for PNG export (default: 1)
 - `--verbose` - Verbose output
 
 #### `parse`

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - **JSON API** for programmatic use
 - **Auto-layout** using ELK.js (Eclipse Layout Kernel)
 - **Multiple flow directions**: TB (top-bottom), BT, LR, RL
+- **Export to PNG & SVG** with dark mode, custom backgrounds, scale, and padding
 - **Programmable API** for integration into other tools
 
 ## Installation
@@ -60,6 +61,22 @@ excalidraw-cli create flowchart.dsl -o diagram.excalidraw
 
 # From stdin
 echo "[A] -> [B] -> [C]" | excalidraw-cli create --stdin -o diagram.excalidraw
+```
+
+### Export to Image
+
+```bash
+# Export while creating a flowchart
+excalidraw-cli create --inline "[A] -> [B]" -o flow.excalidraw --export-as svg
+
+# Export an existing .excalidraw file to PNG
+excalidraw-cli export diagram.excalidraw -F png
+
+# Export with options
+excalidraw-cli export diagram.excalidraw -F png --export-scale 2 --dark-mode
+
+# Export SVG without background
+excalidraw-cli export diagram.excalidraw -F svg --no-export-background
 ```
 
 ### DSL Syntax
@@ -108,6 +125,32 @@ excalidraw-cli create [input] [options]
 - `--stdin` - Read from stdin
 - `-d, --direction <dir>` - Flow direction: TB, BT, LR, RL
 - `-s, --spacing <n>` - Node spacing in pixels
+- `-e, --export-as <format>` - Also export as image: `png` or `svg`
+- `--export-background / --no-export-background` - Include or exclude background (default: include)
+- `--background-color <color>` - Background color (default: #ffffff)
+- `--dark-mode` - Export with dark mode theme
+- `--embed-scene` - Embed scene data in exported image
+- `--export-padding <n>` - Padding around content in pixels (default: 10)
+- `--export-scale <n>` - Scale factor for PNG export (default: 1)
+- `--verbose` - Verbose output
+
+#### `export`
+
+Export an existing `.excalidraw` file to PNG or SVG.
+
+```bash
+excalidraw-cli export <input> [options]
+```
+
+**Options:**
+- `-F, --format <format>` - **(required)** Export format: `png` or `svg`
+- `-o, --output <file>` - Output file path (default: input file with swapped extension)
+- `--export-background / --no-export-background` - Include or exclude background
+- `--background-color <color>` - Background color (default: #ffffff)
+- `--dark-mode` - Export with dark mode theme
+- `--embed-scene` - Embed scene data in exported image
+- `--export-padding <n>` - Padding around content in pixels (default: 10)
+- `--export-scale <n>` - Scale factor for PNG export (default: 1)
 - `--verbose` - Verbose output
 
 #### `parse`
@@ -147,7 +190,12 @@ excalidraw-cli create flowchart.json -o diagram.excalidraw
 ## Programmatic Usage
 
 ```typescript
-import { createFlowchartFromDSL, createFlowchartFromJSON } from 'excalidraw-cli';
+import {
+  createFlowchartFromDSL,
+  createFlowchartFromJSON,
+  exportToSVG,
+  exportToPNG,
+} from '@swiftlysingh/excalidraw-cli';
 
 // From DSL
 const dsl = '(Start) -> [Process] -> (End)';
@@ -162,6 +210,27 @@ const input = {
   edges: [{ from: 'a', to: 'b' }]
 };
 const json2 = await createFlowchartFromJSON(input);
+```
+
+### Export API
+
+```typescript
+import { exportToSVG, exportToPNG } from '@swiftlysingh/excalidraw-cli';
+import { readFileSync, writeFileSync } from 'fs';
+
+// Load an existing .excalidraw file
+const file = JSON.parse(readFileSync('diagram.excalidraw', 'utf-8'));
+
+// Export to SVG
+const svg = await exportToSVG(file, { exportPadding: 20 });
+writeFileSync('diagram.svg', svg);
+
+// Export to PNG with 2x scale and dark mode
+const png = await exportToPNG(file, {
+  exportScale: 2,
+  exportWithDarkMode: true,
+});
+writeFileSync('diagram.png', png);
 ```
 
 ## Examples
@@ -184,6 +253,11 @@ The generated `.excalidraw` files can be:
 1. Opened directly in [Excalidraw](https://excalidraw.com) (File > Open)
 2. Imported into Obsidian with the Excalidraw plugin
 3. Used with any tool that supports the Excalidraw format
+
+With the `--export-as` flag or `export` command, you can also generate:
+
+- **SVG** — scalable vector graphics, ideal for embedding in docs or web pages
+- **PNG** — raster images at any scale (1×, 2×, 3×, etc.) for presentations or sharing
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,13 @@
 - **Export to PNG & SVG** with dark mode, custom backgrounds, scale, and padding
 - **Programmable API** for integration into other tools
 
+## Requirements
+
+- **Node.js** `^20.19.0 || ^22.12.0 || >=24.0.0`
+
 ## Installation
 
-### Using the npm
+### Using npm
 
 ```bash
 npm i @swiftlysingh/excalidraw-cli
@@ -120,7 +124,7 @@ excalidraw-cli create [input] [options]
 
 **Options:**
 - `-o, --output <file>` - Output file path (default: flowchart.excalidraw)
-- `-f, --format <type>` - Input format: dsl, json (default: dsl)
+- `-f, --format <type>` - Input format: dsl, json, dot (default: dsl)
 - `--inline <dsl>` - Inline DSL string
 - `--stdin` - Read from stdin
 - `-d, --direction <dir>` - Flow direction: TB, BT, LR, RL
@@ -254,7 +258,7 @@ The generated `.excalidraw` files can be:
 2. Imported into Obsidian with the Excalidraw plugin
 3. Used with any tool that supports the Excalidraw format
 
-With the `--export-as` flag or `export` command, you can also generate:
+With the `--export-as` flag or `convert` command, you can also generate:
 
 - **SVG** — scalable vector graphics, ideal for embedding in docs or web pages
 - **PNG** — raster images at any scale (1×, 2×, 3×, etc.) for presentations or sharing

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ excalidraw-cli create --inline "[A] -> [B]" -o flow.excalidraw --export-as svg
 excalidraw-cli convert diagram.excalidraw --format png
 
 # Convert with options
-excalidraw-cli convert diagram.excalidraw --format png --scale 2 --dark-mode
+excalidraw-cli convert diagram.excalidraw --format png --scale 2 --dark
 
 # Convert to SVG without background
 excalidraw-cli convert diagram.excalidraw --format svg --no-export-background
@@ -128,7 +128,7 @@ excalidraw-cli create [input] [options]
 - `-e, --export-as <format>` - Also export as image: `png` or `svg`
 - `--export-background / --no-export-background` - Include or exclude background (default: include)
 - `--background-color <color>` - Background color (default: #ffffff)
-- `--dark-mode` - Export with dark mode theme
+- `--dark` - Export with dark mode theme
 - `--embed-scene` - Embed scene data in exported image
 - `--export-padding <n>` - Padding around content in pixels (default: 10)
 - `--scale <n>` - Scale factor for PNG export (default: 1)
@@ -147,7 +147,7 @@ excalidraw-cli convert <input> [options]
 - `-o, --output <file>` - Output file path (default: input file with swapped extension)
 - `--export-background / --no-export-background` - Include or exclude background
 - `--background-color <color>` - Background color (default: #ffffff)
-- `--dark-mode` - Export with dark mode theme
+- `--dark` - Export with dark mode theme
 - `--embed-scene` - Embed scene data in exported image
 - `--export-padding <n>` - Padding around content in pixels (default: 10)
 - `--scale <n>` - Scale factor for PNG export (default: 1)
@@ -193,8 +193,8 @@ excalidraw-cli create flowchart.json -o diagram.excalidraw
 import {
   createFlowchartFromDSL,
   createFlowchartFromJSON,
-  exportToSVG,
-  exportToPNG,
+  convertToSVG,
+  convertToPNG,
 } from '@swiftlysingh/excalidraw-cli';
 
 // From DSL
@@ -215,18 +215,18 @@ const json2 = await createFlowchartFromJSON(input);
 ### Export API
 
 ```typescript
-import { exportToSVG, exportToPNG } from '@swiftlysingh/excalidraw-cli';
+import { convertToSVG, convertToPNG } from '@swiftlysingh/excalidraw-cli';
 import { readFileSync, writeFileSync } from 'fs';
 
 // Load an existing .excalidraw file
 const file = JSON.parse(readFileSync('diagram.excalidraw', 'utf-8'));
 
 // Export to SVG
-const svg = await exportToSVG(file, { exportPadding: 20 });
+const svg = await convertToSVG(file, { exportPadding: 20 });
 writeFileSync('diagram.svg', svg);
 
 // Export to PNG with 2x scale and dark mode
-const png = await exportToPNG(file, {
+const png = await convertToPNG(file, {
   exportScale: 2,
   exportWithDarkMode: true,
 });

--- a/README.md
+++ b/README.md
@@ -231,8 +231,8 @@ writeFileSync('diagram.svg', svg);
 
 // Export to PNG with 2x scale and dark mode
 const png = await convertToPNG(file, {
-  exportScale: 2,
-  exportWithDarkMode: true,
+  scale: 2,
+  dark: true,
 });
 writeFileSync('diagram.png', png);
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@
 
 - **Node.js** `^20.19.0 || ^22.12.0 || >=24.0.0`
 
+> **Note:** This package pins `@excalidraw/utils` to a prerelease version
+> (`0.1.3-test32`) because it is the npm `latest` tag and the only version that
+> ships `exportToSvg` and bundled fonts. See [DEPENDENCIES.md](DEPENDENCIES.md)
+> for details.
+
 ## Installation
 
 ### Using npm

--- a/README.md
+++ b/README.md
@@ -70,9 +70,6 @@ echo "[A] -> [B] -> [C]" | excalidraw-cli create --stdin -o diagram.excalidraw
 ### Export to Image
 
 ```bash
-# Export while creating a flowchart
-excalidraw-cli create --inline "[A] -> [B]" -o flow.excalidraw --export-as svg
-
 # Convert an existing .excalidraw file to PNG
 excalidraw-cli convert diagram.excalidraw --format png
 
@@ -129,13 +126,6 @@ excalidraw-cli create [input] [options]
 - `--stdin` - Read from stdin
 - `-d, --direction <dir>` - Flow direction: TB, BT, LR, RL
 - `-s, --spacing <n>` - Node spacing in pixels
-- `-e, --export-as <format>` - Also export as image: `png` or `svg`
-- `--export-background / --no-export-background` - Include or exclude background (default: include)
-- `--background-color <color>` - Background color (default: #ffffff)
-- `--dark` - Export with dark mode theme
-- `--embed-scene` - Embed scene data in exported image
-- `--export-padding <n>` - Padding around content in pixels (default: 10)
-- `--scale <n>` - Scale factor for PNG export (default: 1)
 - `--verbose` - Verbose output
 
 #### `convert`
@@ -153,7 +143,7 @@ excalidraw-cli convert <input> [options]
 - `--background-color <color>` - Background color (default: #ffffff)
 - `--dark` - Export with dark mode theme
 - `--embed-scene` - Embed scene data in exported image
-- `--export-padding <n>` - Padding around content in pixels (default: 10)
+- `--padding <n>` - Padding around content in pixels (default: 10)
 - `--scale <n>` - Scale factor for PNG export (default: 1)
 - `--verbose` - Verbose output
 
@@ -226,7 +216,7 @@ import { readFileSync, writeFileSync } from 'fs';
 const file = JSON.parse(readFileSync('diagram.excalidraw', 'utf-8'));
 
 // Export to SVG
-const svg = await convertToSVG(file, { exportPadding: 20 });
+const svg = await convertToSVG(file, { padding: 20 });
 writeFileSync('diagram.svg', svg);
 
 // Export to PNG with 2x scale and dark mode
@@ -258,7 +248,7 @@ The generated `.excalidraw` files can be:
 2. Imported into Obsidian with the Excalidraw plugin
 3. Used with any tool that supports the Excalidraw format
 
-With the `--export-as` flag or `convert` command, you can also generate:
+With the `convert` command, you can also generate:
 
 - **SVG** — scalable vector graphics, ideal for embedding in docs or web pages
 - **PNG** — raster images at any scale (1×, 2×, 3×, etc.) for presentations or sharing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,19 @@
 {
   "name": "@swiftlysingh/excalidraw-cli",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@swiftlysingh/excalidraw-cli",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
+        "@excalidraw/utils": "^0.1.3-test32",
+        "@resvg/resvg-js": "^2.6.2",
         "commander": "^12.1.0",
         "elkjs": "^0.9.3",
+        "jsdom": "^28.1.0",
         "nanoid": "^5.0.9",
         "ts-graphviz": "^3.0.6"
       },
@@ -18,6 +21,7 @@
         "excalidraw-cli": "dist/cli.js"
       },
       "devDependencies": {
+        "@types/jsdom": "^27.0.0",
         "@types/node": "^22.10.5",
         "@typescript-eslint/eslint-plugin": "^8.19.1",
         "@typescript-eslint/parser": "^8.19.1",
@@ -28,6 +32,188 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.2.tgz",
+      "integrity": "sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg==",
+      "license": "MIT"
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.28.tgz",
+      "integrity": "sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -610,6 +796,47 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@excalidraw/laser-pointer": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@excalidraw/laser-pointer/-/laser-pointer-1.3.1.tgz",
+      "integrity": "sha512-psA1z1N2qeAfsORdXc9JmD2y4CmDwmuMRxnNdJHZexIcPwaNEyIpNcelw+QkL9rz9tosaN9krXuKaRqYpRAR6g==",
+      "license": "MIT"
+    },
+    "node_modules/@excalidraw/utils": {
+      "version": "0.1.3-test32",
+      "resolved": "https://registry.npmjs.org/@excalidraw/utils/-/utils-0.1.3-test32.tgz",
+      "integrity": "sha512-xOXYkkR6bRneoW4in5Ha5Iz2PyS9R9vPpzW7jcTOEE1ae9D5cz5hwBT8BxXfGKWp+YTCyHRHIJaa0ZhlW4H5nQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "6.0.2",
+        "@excalidraw/laser-pointer": "1.3.1",
+        "browser-fs-access": "0.29.1",
+        "open-color": "1.9.1",
+        "pako": "2.0.3",
+        "perfect-freehand": "1.2.0",
+        "png-chunk-text": "1.0.0",
+        "png-chunks-encode": "1.0.0",
+        "png-chunks-extract": "1.0.0",
+        "roughjs": "4.6.4"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
+      "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -668,6 +895,221 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.55.1",
@@ -1112,6 +1554,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-27.0.0.tgz",
+      "integrity": "sha512-NZyFl/PViwKzdEkQg96gtnB8wm+1ljhdDay9ahn4hgb+SfVtPCbm3TlmDUFXTA+MGN3CijicnMhG18SI5H3rFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1128,6 +1595,13 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.52.0",
@@ -1498,6 +1972,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1555,6 +2038,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
@@ -1564,6 +2056,12 @@
       "dependencies": {
         "balanced-match": "^1.0.0"
       }
+    },
+    "node_modules/browser-fs-access": {
+      "version": "0.29.1",
+      "resolved": "https://registry.npmjs.org/browser-fs-access/-/browser-fs-access-0.29.1.tgz",
+      "integrity": "sha512-LSvVX5e21LRrXqVMhqtAwj5xPgDb+fXAIH80NsnCQ9xuZPs2xWsOREi24RKgZa1XOiQRbcmVrv87+ulOKsgjxw==",
+      "license": "Apache-2.0"
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -1665,6 +2163,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/crc-32": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-0.3.0.tgz",
+      "integrity": "sha512-kucVIjOmMc1f0tv53BJ/5WIX+MGLcKuoBhnGqQrgKJNqLByb/sVMWfW/Aw6hw0jgcqjJ2pi9E5y32zOIpaUlsA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1680,11 +2187,51 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.0.1.tgz",
+      "integrity": "sha512-IoJs7La+oFp/AB033wBStxNOJt4+9hHMxsXUPANcoXL2b3W4DZKghlJ2cI/eyeRZIQ9ysvYEorVhjrcYctWbog==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.26",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1697,6 +2244,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -1720,6 +2273,18 @@
       "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
       "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
       "license": "EPL-2.0"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -2145,6 +2710,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2153,6 +2724,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ignore": {
@@ -2215,6 +2824,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2233,6 +2848,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -2310,6 +2965,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2319,6 +2983,12 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "license": "CC0-1.0"
     },
     "node_modules/minimatch": {
       "version": "9.0.5",
@@ -2340,7 +3010,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2366,6 +3035,12 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/open-color": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/open-color/-/open-color-1.9.1.tgz",
+      "integrity": "sha512-vCseG/EQ6/RcvxhUcGJiHViOgrtz4x0XbZepXvKik66TMGkvbmjeJrKFyBEx6daG5rNyyd14zYXhz0hZVwQFOw==",
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -2418,6 +3093,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.3.tgz",
+      "integrity": "sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2430,6 +3111,24 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -2468,6 +3167,12 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/perfect-freehand": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/perfect-freehand/-/perfect-freehand-1.2.0.tgz",
+      "integrity": "sha512-h/0ikF1M3phW7CwpZ5MMvKnfpHficWoOEyr//KVNTxV4F6deRK1eYMtHyBKEAKFK0aXIEUK9oBvlF6PNXMDsAw==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2486,6 +3191,47 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/png-chunk-text": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-chunk-text/-/png-chunk-text-1.0.0.tgz",
+      "integrity": "sha512-DEROKU3SkkLGWNMzru3xPVgxyd48UGuMSZvioErCure6yhOc/pRH2ZV+SEn7nmaf7WNf3NdIpH+UTrRdKyq9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/png-chunks-encode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-chunks-encode/-/png-chunks-encode-1.0.0.tgz",
+      "integrity": "sha512-J1jcHgbQRsIIgx5wxW9UmCymV3wwn4qCCJl6KYgEU/yHCh/L2Mwq/nMOkRPtmV79TLxRZj5w3tH69pvygFkDqA==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^0.3.0",
+        "sliced": "^1.0.1"
+      }
+    },
+    "node_modules/png-chunks-extract": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/png-chunks-extract/-/png-chunks-extract-1.0.0.tgz",
+      "integrity": "sha512-ZiVwF5EJ0DNZyzAqld8BP1qyJBaGOFaq9zl579qfbkcmOwWLLO4I9L8i2O4j3HkI6/35i0nKG2n+dZplxiT89Q==",
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^0.3.0"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/postcss": {
@@ -2566,10 +3312,18 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2627,6 +3381,30 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/roughjs": {
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.4.tgz",
+      "integrity": "sha512-s6EZ0BntezkFYMf/9mGn7M8XGIoaav9QQBCnJROWB3brUWQ683Q2LbRD/hq0Z3bAJ/9NVpU/5LpiTWvQMyLDhw==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -2670,11 +3448,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sliced": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -2719,6 +3502,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -2779,6 +3568,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
+      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.23"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -2844,6 +3675,15 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -3012,6 +3852,50 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3054,6 +3938,21 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -37,12 +37,16 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@excalidraw/utils": "^0.1.3-test32",
+    "@resvg/resvg-js": "^2.6.2",
     "commander": "^12.1.0",
     "elkjs": "^0.9.3",
+    "jsdom": "^28.1.0",
     "nanoid": "^5.0.9",
     "ts-graphviz": "^3.0.6"
   },
   "devDependencies": {
+    "@types/jsdom": "^27.0.0",
     "@types/node": "^22.10.5",
     "@typescript-eslint/eslint-plugin": "^8.19.1",
     "@typescript-eslint/parser": "^8.19.1",

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "dist"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
   },
   "dependencies": {
-    "@excalidraw/utils": "^0.1.3-test32",
+    "@excalidraw/utils": "0.1.3-test32",
     "@resvg/resvg-js": "^2.6.2",
     "commander": "^12.1.0",
     "elkjs": "^0.9.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dist"
   ],
   "engines": {
-    "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+    "node": ">=18.0.0"
   },
   "dependencies": {
     "@excalidraw/utils": "0.1.3-test32",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,7 +13,7 @@ import { parseJSONString } from './parser/json-parser.js';
 import { parseDOT } from './parser/dot-parser.js';
 import { layoutGraph } from './layout/elk-layout.js';
 import { generateExcalidraw, serializeExcalidraw } from './generator/excalidraw-generator.js';
-import { exportImage, swapExtension } from './exporter/index.js';
+import { convertImage, swapExtension } from './exporter/index.js';
 import type { ExportOptions } from './exporter/index.js';
 import type { ExcalidrawFile } from './types/excalidraw.js';
 import type { FlowchartGraph, FlowDirection } from './types/dsl.js';
@@ -42,7 +42,7 @@ program
   .option('--export-background', 'Include background in export (default: true)')
   .option('--no-export-background', 'Exclude background from export')
   .option('--background-color <color>', 'Background color for export (default: #ffffff)')
-  .option('--dark-mode', 'Export with dark mode')
+  .option('--dark', 'Export with dark mode')
   .option('--embed-scene', 'Embed scene data in exported image')
   .option('--export-padding <n>', 'Padding around exported content in pixels', '10')
   .option('--scale <n>', 'Scale factor for PNG export (default: 1)', '1')
@@ -139,7 +139,7 @@ program
           format: format as 'png' | 'svg',
           exportBackground: options.exportBackground !== false,
           viewBackgroundColor: options.backgroundColor,
-          exportWithDarkMode: options.darkMode || false,
+          exportWithDarkMode: options.dark || false,
           exportEmbedScene: options.embedScene || false,
           exportPadding: parseInt(options.exportPadding, 10) || 10,
           exportScale: parseFloat(options.scale) || 1,
@@ -154,7 +154,7 @@ program
           console.log(`Exporting as ${format.toUpperCase()}...`);
         }
 
-        const result = await exportImage(excalidrawFile, exportOpts);
+        const result = await convertImage(excalidrawFile, exportOpts);
 
         if (typeof result === 'string') {
           writeFileSync(imageOutput, result, 'utf-8');
@@ -235,7 +235,7 @@ program
   .option('--export-background', 'Include background in export (default: true)')
   .option('--no-export-background', 'Exclude background from export')
   .option('--background-color <color>', 'Background color (default: #ffffff)')
-  .option('--dark-mode', 'Export with dark mode')
+  .option('--dark', 'Export with dark mode')
   .option('--embed-scene', 'Embed scene data in exported image')
   .option('--export-padding <n>', 'Padding around content in pixels', '10')
   .option('--scale <n>', 'Scale factor for PNG export', '1')
@@ -262,7 +262,7 @@ program
         format: format as 'png' | 'svg',
         exportBackground: options.exportBackground !== false,
         viewBackgroundColor: options.backgroundColor,
-        exportWithDarkMode: options.darkMode || false,
+        exportWithDarkMode: options.dark || false,
         exportEmbedScene: options.embedScene || false,
         exportPadding: parseInt(options.exportPadding, 10) || 10,
         exportScale: parseFloat(options.scale) || 1,
@@ -274,7 +274,7 @@ program
         console.log(`Exporting as ${format.toUpperCase()} to ${outputPath}...`);
       }
 
-      const result = await exportImage(excalidrawFile, exportOpts);
+      const result = await convertImage(excalidrawFile, exportOpts);
 
       if (typeof result === 'string') {
         writeFileSync(outputPath, result, 'utf-8');

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -213,14 +213,26 @@ program
         console.log(`Files: ${Object.keys(excalidrawFile.files || {}).length}`);
       }
 
+      const padding = parseInt(options.padding, 10);
+      if (Number.isNaN(padding) || padding < 0) {
+        console.error('Error: --padding must be a non-negative integer');
+        process.exit(1);
+      }
+
+      const scale = parseFloat(options.scale);
+      if (Number.isNaN(scale) || scale <= 0) {
+        console.error('Error: --scale must be a positive number');
+        process.exit(1);
+      }
+
       const exportOpts: ExportOptions = {
         format: format as 'png' | 'svg',
         exportBackground: options.exportBackground !== false,
         viewBackgroundColor: options.backgroundColor,
         dark: options.dark || false,
         exportEmbedScene: options.embedScene || false,
-        padding: parseInt(options.padding, 10),
-        scale: parseFloat(options.scale),
+        padding,
+        scale,
       };
 
       const outputPath = options.output || swapExtension(inputFile, format);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,14 +38,6 @@ program
   .option('--stdin', 'Read input from stdin')
   .option('-d, --direction <dir>', 'Flow direction: TB, BT, LR, RL (default: TB)')
   .option('-s, --spacing <n>', 'Node spacing in pixels', '50')
-  .option('-e, --export-as <format>', 'Export as image format: png or svg')
-  .option('--export-background', 'Include background in export (default: true)')
-  .option('--no-export-background', 'Exclude background from export')
-  .option('--background-color <color>', 'Background color for export (default: #ffffff)')
-  .option('--dark', 'Export with dark mode')
-  .option('--embed-scene', 'Embed scene data in exported image')
-  .option('--export-padding <n>', 'Padding around exported content in pixels', '10')
-  .option('--scale <n>', 'Scale factor for PNG export (default: 1)', '1')
   .option('--verbose', 'Verbose output')
   .action(async (inputFile, options, command) => {
     try {
@@ -126,43 +118,6 @@ program
         writeFileSync(options.output, output, 'utf-8');
         console.log(`Created: ${options.output}`);
       }
-
-      // Export as image if requested
-      if (options.exportAs) {
-        const format = options.exportAs.toLowerCase();
-        if (format !== 'png' && format !== 'svg') {
-          console.error('Error: --export-as must be "png" or "svg"');
-          process.exit(1);
-        }
-
-        const exportOpts: ExportOptions = {
-          format: format as 'png' | 'svg',
-          exportBackground: options.exportBackground !== false,
-          viewBackgroundColor: options.backgroundColor,
-          dark: options.dark || false,
-          exportEmbedScene: options.embedScene || false,
-        exportPadding: parseInt(options.exportPadding, 10),
-        scale: parseFloat(options.scale),
-        };
-
-        const imageOutput = swapExtension(
-          options.output === '-' ? 'flowchart.excalidraw' : options.output,
-          format
-        );
-
-        if (options.verbose) {
-          console.log(`Exporting as ${format.toUpperCase()}...`);
-        }
-
-        const result = await convertImage(excalidrawFile, exportOpts);
-
-        if (typeof result === 'string') {
-          writeFileSync(imageOutput, result, 'utf-8');
-        } else {
-          writeFileSync(imageOutput, result);
-        }
-        console.log(`Exported: ${imageOutput}`);
-      }
     } catch (error) {
       console.error('Error:', error instanceof Error ? error.message : error);
       process.exit(1);
@@ -237,7 +192,7 @@ program
   .option('--background-color <color>', 'Background color (default: #ffffff)')
   .option('--dark', 'Export with dark mode')
   .option('--embed-scene', 'Embed scene data in exported image')
-  .option('--export-padding <n>', 'Padding around content in pixels', '10')
+  .option('--padding <n>', 'Padding around content in pixels', '10')
   .option('--scale <n>', 'Scale factor for PNG export', '1')
   .option('--verbose', 'Verbose output')
   .action(async (inputFile, options) => {
@@ -264,7 +219,7 @@ program
         viewBackgroundColor: options.backgroundColor,
         dark: options.dark || false,
         exportEmbedScene: options.embedScene || false,
-        exportPadding: parseInt(options.exportPadding, 10),
+        padding: parseInt(options.padding, 10),
         scale: parseFloat(options.scale),
       };
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,7 +45,7 @@ program
   .option('--dark-mode', 'Export with dark mode')
   .option('--embed-scene', 'Embed scene data in exported image')
   .option('--export-padding <n>', 'Padding around exported content in pixels', '10')
-  .option('--export-scale <n>', 'Scale factor for PNG export (default: 1)', '1')
+  .option('--scale <n>', 'Scale factor for PNG export (default: 1)', '1')
   .option('--verbose', 'Verbose output')
   .action(async (inputFile, options, command) => {
     try {
@@ -142,7 +142,7 @@ program
           exportWithDarkMode: options.darkMode || false,
           exportEmbedScene: options.embedScene || false,
           exportPadding: parseInt(options.exportPadding, 10) || 10,
-          exportScale: parseFloat(options.exportScale) || 1,
+          exportScale: parseFloat(options.scale) || 1,
         };
 
         const imageOutput = swapExtension(
@@ -224,13 +224,13 @@ program
   });
 
 /**
- * Export command - convert an existing .excalidraw file to PNG or SVG
+ * Convert command - convert an existing .excalidraw file to PNG or SVG
  */
 program
-  .command('export')
-  .description('Export an existing .excalidraw file to PNG or SVG')
+  .command('convert')
+  .description('Convert an existing .excalidraw file to PNG or SVG')
   .argument('<input>', 'Input .excalidraw file path')
-  .requiredOption('-F, --format <format>', 'Export format: png or svg')
+  .requiredOption('--format <format>', 'Export format: png or svg')
   .option('-o, --output <file>', 'Output file path (default: input file with swapped extension)')
   .option('--export-background', 'Include background in export (default: true)')
   .option('--no-export-background', 'Exclude background from export')
@@ -238,7 +238,7 @@ program
   .option('--dark-mode', 'Export with dark mode')
   .option('--embed-scene', 'Embed scene data in exported image')
   .option('--export-padding <n>', 'Padding around content in pixels', '10')
-  .option('--export-scale <n>', 'Scale factor for PNG export', '1')
+  .option('--scale <n>', 'Scale factor for PNG export', '1')
   .option('--verbose', 'Verbose output')
   .action(async (inputFile, options) => {
     try {
@@ -265,7 +265,7 @@ program
         exportWithDarkMode: options.darkMode || false,
         exportEmbedScene: options.embedScene || false,
         exportPadding: parseInt(options.exportPadding, 10) || 10,
-        exportScale: parseFloat(options.exportScale) || 1,
+        exportScale: parseFloat(options.scale) || 1,
       };
 
       const outputPath = options.output || swapExtension(inputFile, format);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -139,10 +139,10 @@ program
           format: format as 'png' | 'svg',
           exportBackground: options.exportBackground !== false,
           viewBackgroundColor: options.backgroundColor,
-          exportWithDarkMode: options.dark || false,
+          dark: options.dark || false,
           exportEmbedScene: options.embedScene || false,
         exportPadding: parseInt(options.exportPadding, 10),
-        exportScale: parseFloat(options.scale),
+        scale: parseFloat(options.scale),
         };
 
         const imageOutput = swapExtension(
@@ -262,10 +262,10 @@ program
         format: format as 'png' | 'svg',
         exportBackground: options.exportBackground !== false,
         viewBackgroundColor: options.backgroundColor,
-        exportWithDarkMode: options.dark || false,
+        dark: options.dark || false,
         exportEmbedScene: options.embedScene || false,
         exportPadding: parseInt(options.exportPadding, 10),
-        exportScale: parseFloat(options.scale),
+        scale: parseFloat(options.scale),
       };
 
       const outputPath = options.output || swapExtension(inputFile, format);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -141,8 +141,8 @@ program
           viewBackgroundColor: options.backgroundColor,
           exportWithDarkMode: options.dark || false,
           exportEmbedScene: options.embedScene || false,
-          exportPadding: parseInt(options.exportPadding, 10) || 10,
-          exportScale: parseFloat(options.scale) || 1,
+        exportPadding: parseInt(options.exportPadding, 10),
+        exportScale: parseFloat(options.scale),
         };
 
         const imageOutput = swapExtension(
@@ -264,8 +264,8 @@ program
         viewBackgroundColor: options.backgroundColor,
         exportWithDarkMode: options.dark || false,
         exportEmbedScene: options.embedScene || false,
-        exportPadding: parseInt(options.exportPadding, 10) || 10,
-        exportScale: parseFloat(options.scale) || 1,
+        exportPadding: parseInt(options.exportPadding, 10),
+        exportScale: parseFloat(options.scale),
       };
 
       const outputPath = options.output || swapExtension(inputFile, format);

--- a/src/exporter/dom-polyfill.ts
+++ b/src/exporter/dom-polyfill.ts
@@ -24,7 +24,10 @@ const FONT_PROXY_BASE = 'https://excalidraw-fonts.local/';
 let polyfillApplied = false;
 
 /**
- * Resolve the path to @excalidraw/utils bundled font assets directory
+ * Resolve the absolute path to the `@excalidraw/utils` bundled font
+ * assets directory (contains `.ttf` / `.woff2` files).
+ *
+ * @returns Absolute path to the assets directory.
  */
 function getAssetsDir(): string {
   const require = createRequire(import.meta.url);
@@ -35,6 +38,22 @@ function getAssetsDir(): string {
   return resolve(utilsDir, 'assets');
 }
 
+/**
+ * Initialise the minimal browser-like environment that @excalidraw/utils
+ * requires to render SVGs in Node.js.
+ *
+ * This is idempotent — calling it more than once is a no-op.
+ *
+ * What gets polyfilled:
+ * - Core DOM globals via jsdom (`window`, `document`, `navigator`, etc.)
+ * - `Path2D` stub for roughjs shape generation
+ * - `FontFace` constructor with `unicodeRange` support
+ * - `document.fonts` (`FontFaceSet`) for font registration
+ * - `fetch()` override to load bundled font files from disk
+ * - `EXCALIDRAW_ASSET_PATH` pointed at the local font proxy URL
+ *
+ * @returns A promise that resolves once the polyfill is in place.
+ */
 export async function ensureDOMPolyfill(): Promise<void> {
   if (polyfillApplied) return;
 

--- a/src/exporter/dom-polyfill.ts
+++ b/src/exporter/dom-polyfill.ts
@@ -189,6 +189,10 @@ export async function ensureDOMPolyfill(): Promise<void> {
     if (url.startsWith(FONT_PROXY_BASE)) {
       // Extract font filename from the URL
       const fontFile = decodeURIComponent(url.slice(FONT_PROXY_BASE.length));
+      // Prevent path traversal attacks
+      if (fontFile.includes('..') || fontFile.startsWith('/')) {
+        return new Response(null, { status: 400, statusText: 'Invalid font path' });
+      }
       const fontPath = resolve(assetsDir, fontFile);
 
       try {

--- a/src/exporter/dom-polyfill.ts
+++ b/src/exporter/dom-polyfill.ts
@@ -1,0 +1,193 @@
+/**
+ * DOM Polyfill for Node.js
+ *
+ * Sets up the minimum browser globals required by @excalidraw/utils
+ * to render SVGs in a Node.js environment using jsdom.
+ *
+ * Key features:
+ * - jsdom for core DOM (document, window, DOMParser, etc.)
+ * - Path2D stub for roughjs shape generation
+ * - FontFace polyfill that works with @excalidraw/utils font loading
+ * - document.fonts (FontFaceSet) polyfill for font registration
+ * - fetch() override to load font files from disk via file:// URLs
+ * - EXCALIDRAW_ASSET_PATH pointing to bundled font assets
+ */
+
+import { createRequire } from 'node:module';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { resolve, dirname } from 'node:path';
+
+/** Fake base URL used to route font fetches through our local file override */
+const FONT_PROXY_BASE = 'https://excalidraw-fonts.local/';
+
+let polyfillApplied = false;
+
+/**
+ * Resolve the path to @excalidraw/utils bundled font assets directory
+ */
+function getAssetsDir(): string {
+  const require = createRequire(import.meta.url);
+  const utilsEntry = require.resolve('@excalidraw/utils');
+  // Navigate from the entry point to the assets directory
+  // Typical structure: .../dist/prod/index.js → .../dist/prod/assets/
+  const utilsDir = dirname(utilsEntry);
+  return resolve(utilsDir, 'assets');
+}
+
+export async function ensureDOMPolyfill(): Promise<void> {
+  if (polyfillApplied) return;
+
+  const { JSDOM } = await import('jsdom');
+  const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', {
+    url: 'https://localhost',
+    pretendToBeVisual: true,
+  });
+
+  const g = globalThis as Record<string, unknown>;
+  const win = dom.window as unknown as Record<string, unknown>;
+
+  // Core DOM globals
+  g.window = dom.window;
+  g.document = dom.window.document;
+  g.navigator = dom.window.navigator;
+  g.DOMParser = dom.window.DOMParser;
+  g.Node = dom.window.Node;
+
+  // Canvas/rendering globals
+  g.devicePixelRatio = 1;
+
+  // Path2D polyfill (used by roughjs shape generation in excalidraw)
+  g.Path2D = class Path2D {
+    d: string;
+    constructor(path?: string) {
+      this.d = path || '';
+    }
+    addPath() { /* no-op */ }
+    moveTo() { /* no-op */ }
+    lineTo() { /* no-op */ }
+    bezierCurveTo() { /* no-op */ }
+    quadraticCurveTo() { /* no-op */ }
+    arc() { /* no-op */ }
+    arcTo() { /* no-op */ }
+    ellipse() { /* no-op */ }
+    rect() { /* no-op */ }
+    closePath() { /* no-op */ }
+  };
+
+  // FontFace polyfill with real data tracking
+  // @excalidraw/utils reads: fontFace.family, fontFace.unicodeRange
+  const FontFaceImpl = class FontFace {
+    family: string;
+    source: string;
+    descriptors: Record<string, string>;
+    status = 'loaded';
+    loaded: Promise<FontFace>;
+    display: string;
+    style: string;
+    weight: string;
+    unicodeRange: string;
+    featureSettings: string;
+
+    constructor(family: string, source: string | ArrayBuffer, descriptors?: Record<string, string>) {
+      this.family = family;
+      this.source = typeof source === 'string' ? source : 'arraybuffer';
+      this.descriptors = descriptors || {};
+      this.display = descriptors?.display || 'swap';
+      this.style = descriptors?.style || 'normal';
+      this.weight = descriptors?.weight || '400';
+      // unicodeRange is critical: @excalidraw/utils calls fontFace.unicodeRange.split(...)
+      this.unicodeRange = descriptors?.unicodeRange || 'U+0000-FFFF';
+      this.featureSettings = descriptors?.featureSettings || '';
+      this.loaded = Promise.resolve(this);
+    }
+    load(): Promise<FontFace> {
+      return Promise.resolve(this);
+    }
+  };
+  g.FontFace = FontFaceImpl;
+
+  // FontFaceSet polyfill — tracks registered FontFace instances
+  // @excalidraw/utils uses document.fonts.add(), .has(), .check(), .load()
+  const fontSet = new Set<InstanceType<typeof FontFaceImpl>>();
+  const fontFaceSet = {
+    add(face: InstanceType<typeof FontFaceImpl>) {
+      fontSet.add(face);
+    },
+    has(face: InstanceType<typeof FontFaceImpl>) {
+      return fontSet.has(face);
+    },
+    delete(face: InstanceType<typeof FontFaceImpl>) {
+      return fontSet.delete(face);
+    },
+    // check() and load() return true/resolved — we pretend all fonts are available
+    check(_font: string, _text?: string) {
+      return true;
+    },
+    load(_font: string, _text?: string) {
+      return Promise.resolve([]);
+    },
+    forEach(cb: (face: InstanceType<typeof FontFaceImpl>) => void) {
+      fontSet.forEach(cb);
+    },
+    get size() {
+      return fontSet.size;
+    },
+    get status() {
+      return 'loaded';
+    },
+    ready: Promise.resolve(),
+    [Symbol.iterator]() {
+      return fontSet[Symbol.iterator]();
+    },
+  };
+
+  // Assign document.fonts
+  const doc = dom.window.document as unknown as Record<string, unknown>;
+  Object.defineProperty(doc, 'fonts', {
+    value: fontFaceSet,
+    writable: true,
+    configurable: true,
+  });
+
+  // Also set on window for @excalidraw/utils access patterns
+  win.EXCALIDRAW_ASSET_PATH = FONT_PROXY_BASE;
+
+  // Resolve the local assets directory for font file loading
+  const assetsDir = getAssetsDir();
+
+  // Override global fetch to intercept font requests
+  // @excalidraw/utils calls fetch(url) to load font data — we redirect
+  // requests for our proxy base URL to local disk reads
+  const originalFetch = globalThis.fetch;
+  g.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.href
+        : (input as Request).url;
+
+    if (url.startsWith(FONT_PROXY_BASE)) {
+      // Extract font filename from the URL
+      const fontFile = decodeURIComponent(url.slice(FONT_PROXY_BASE.length));
+      const fontPath = resolve(assetsDir, fontFile);
+
+      try {
+        const data = await readFile(fontPath);
+        return new Response(data, {
+          status: 200,
+          headers: {
+            'Content-Type': 'font/ttf',
+          },
+        });
+      } catch {
+        return new Response(null, { status: 404, statusText: 'Font not found' });
+      }
+    }
+
+    // Pass through all other requests to the real fetch
+    return originalFetch(input, init);
+  };
+
+  polyfillApplied = true;
+}

--- a/src/exporter/dom-polyfill.ts
+++ b/src/exporter/dom-polyfill.ts
@@ -15,9 +15,7 @@
 
 import { createRequire } from 'node:module';
 import { readFile } from 'node:fs/promises';
-import { fileURLToPath, pathToFileURL } from 'node:url';
 import { resolve, dirname } from 'node:path';
-
 /** Fake base URL used to route font fetches through our local file override */
 const FONT_PROXY_BASE = 'https://excalidraw-fonts.local/';
 

--- a/src/exporter/dom-polyfill.ts
+++ b/src/exporter/dom-polyfill.ts
@@ -159,7 +159,7 @@ export async function ensureDOMPolyfill(): Promise<void> {
   // Override global fetch to intercept font requests
   // @excalidraw/utils calls fetch(url) to load font data — we redirect
   // requests for our proxy base URL to local disk reads
-  const originalFetch = globalThis.fetch;
+  const originalFetch = globalThis.fetch ?? (() => { throw new Error('fetch not available'); });
   g.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     const url = typeof input === 'string'
       ? input

--- a/src/exporter/image-exporter.ts
+++ b/src/exporter/image-exporter.ts
@@ -70,12 +70,12 @@ function resolveOptions(
 ): Required<ExportOptions> {
   return {
     ...DEFAULT_EXPORT_OPTIONS,
+    ...options,
     // Use appState background color if available
     viewBackgroundColor:
       options.viewBackgroundColor ??
       file.appState?.viewBackgroundColor ??
       DEFAULT_EXPORT_OPTIONS.viewBackgroundColor,
-    ...options,
   };
 }
 

--- a/src/exporter/image-exporter.ts
+++ b/src/exporter/image-exporter.ts
@@ -33,7 +33,7 @@ export interface ExportOptions {
   exportEmbedScene?: boolean;
 
   /** Padding around the exported content in pixels (default: 10) */
-  exportPadding?: number;
+  padding?: number;
 
   /** Scale factor for PNG export (default: 1). Higher values = higher resolution */
   scale?: number;
@@ -48,7 +48,7 @@ export const DEFAULT_EXPORT_OPTIONS: Required<ExportOptions> = {
   viewBackgroundColor: '#ffffff',
   dark: false,
   exportEmbedScene: false,
-  exportPadding: 10,
+  padding: 10,
   scale: 1,
 };
 
@@ -130,7 +130,7 @@ export async function convertToSVG(
       elements: file.elements as unknown[],
       appState: appState as Record<string, unknown>,
       files: (file.files || {}) as Record<string, unknown>,
-      exportPadding: opts.exportPadding,
+      exportPadding: opts.padding,
     });
 
     return svg.outerHTML;

--- a/src/exporter/image-exporter.ts
+++ b/src/exporter/image-exporter.ts
@@ -190,7 +190,13 @@ export async function convertToPNG(
   const naturalWidth = widthMatch ? parseFloat(widthMatch[1]) : 800;
   const naturalHeight = heightMatch ? parseFloat(heightMatch[1]) : 600;
 
-  const scaledWidth = Math.round(naturalWidth * opts.scale);
+  // Sanitize scale to avoid zero, negative, non-finite, or extreme values.
+  const scale =
+    typeof opts.scale === 'number' && Number.isFinite(opts.scale)
+      ? opts.scale
+      : 1;
+  const safeScale = Math.min(Math.max(scale, 0.1), 10);
+  const scaledWidth = Math.round(naturalWidth * safeScale);
 
   // Load Excalidraw font files for text rendering.
   // resvg-js does NOT parse @font-face CSS from SVG — fonts must be

--- a/src/exporter/image-exporter.ts
+++ b/src/exporter/image-exporter.ts
@@ -27,7 +27,7 @@ export interface ExportOptions {
   viewBackgroundColor?: string;
 
   /** Export with dark mode (default: false) */
-  exportWithDarkMode?: boolean;
+  dark?: boolean;
 
   /** Embed scene data into the exported image (default: false) */
   exportEmbedScene?: boolean;
@@ -36,7 +36,7 @@ export interface ExportOptions {
   exportPadding?: number;
 
   /** Scale factor for PNG export (default: 1). Higher values = higher resolution */
-  exportScale?: number;
+  scale?: number;
 }
 
 /**
@@ -46,10 +46,10 @@ export const DEFAULT_EXPORT_OPTIONS: Required<ExportOptions> = {
   format: 'svg',
   exportBackground: true,
   viewBackgroundColor: '#ffffff',
-  exportWithDarkMode: false,
+  dark: false,
   exportEmbedScene: false,
   exportPadding: 10,
-  exportScale: 1,
+  scale: 1,
 };
 
 /**
@@ -112,7 +112,7 @@ export async function convertToSVG(
     ...file.appState,
     exportBackground: opts.exportBackground,
     viewBackgroundColor: opts.viewBackgroundColor,
-    exportWithDarkMode: opts.exportWithDarkMode,
+    exportWithDarkMode: opts.dark,
     exportEmbedScene: opts.exportEmbedScene,
   };
 
@@ -163,7 +163,7 @@ function getExcalidrawFontDir(): string {
  * Convert an Excalidraw file to a PNG image buffer.
  *
  * Pipeline: Excalidraw → SVG (via {@link convertToSVG}) → PNG (via resvg-js).
- * The `exportScale` option controls the output resolution.
+ * The `scale` option controls the output resolution.
  *
  * Font rendering note: `@resvg/resvg-js` ignores `@font-face` CSS inside the
  * SVG, so bundled TTF font files are provided through the `fontDirs` option.
@@ -190,7 +190,7 @@ export async function convertToPNG(
   const naturalWidth = widthMatch ? parseFloat(widthMatch[1]) : 800;
   const naturalHeight = heightMatch ? parseFloat(heightMatch[1]) : 600;
 
-  const scaledWidth = Math.round(naturalWidth * opts.exportScale);
+  const scaledWidth = Math.round(naturalWidth * opts.scale);
 
   // Load Excalidraw font files for text rendering.
   // resvg-js does NOT parse @font-face CSS from SVG — fonts must be

--- a/src/exporter/image-exporter.ts
+++ b/src/exporter/image-exporter.ts
@@ -1,0 +1,204 @@
+/**
+ * Image Exporter
+ *
+ * Exports Excalidraw files to SVG and PNG image formats.
+ * Uses @excalidraw/utils for SVG rendering and @resvg/resvg-js for PNG rasterization.
+ */
+
+import { createRequire } from 'node:module';
+import { resolve, dirname } from 'node:path';
+import { ensureDOMPolyfill } from './dom-polyfill.js';
+import type { ExcalidrawFile } from '../types/excalidraw.js';
+
+/**
+ * Export options matching Excalidraw website capabilities
+ */
+export interface ExportOptions {
+  /** Output format: 'svg' or 'png' */
+  format: 'svg' | 'png';
+
+  /** Whether to include the background in the export (default: true) */
+  exportBackground?: boolean;
+
+  /** Background color (default: from appState or '#ffffff') */
+  viewBackgroundColor?: string;
+
+  /** Export with dark mode (default: false) */
+  exportWithDarkMode?: boolean;
+
+  /** Embed scene data into the exported image (default: false) */
+  exportEmbedScene?: boolean;
+
+  /** Padding around the exported content in pixels (default: 10) */
+  exportPadding?: number;
+
+  /** Scale factor for PNG export (default: 1). Higher values = higher resolution */
+  exportScale?: number;
+}
+
+/**
+ * Default export options
+ */
+export const DEFAULT_EXPORT_OPTIONS: Required<ExportOptions> = {
+  format: 'svg',
+  exportBackground: true,
+  viewBackgroundColor: '#ffffff',
+  exportWithDarkMode: false,
+  exportEmbedScene: false,
+  exportPadding: 10,
+  exportScale: 1,
+};
+
+/**
+ * Merge user options with defaults, applying appState values where appropriate
+ */
+function resolveOptions(
+  file: ExcalidrawFile,
+  options: ExportOptions
+): Required<ExportOptions> {
+  return {
+    ...DEFAULT_EXPORT_OPTIONS,
+    // Use appState background color if available
+    viewBackgroundColor:
+      options.viewBackgroundColor ??
+      file.appState?.viewBackgroundColor ??
+      DEFAULT_EXPORT_OPTIONS.viewBackgroundColor,
+    ...options,
+  };
+}
+
+/**
+ * Export an Excalidraw file to SVG string
+ */
+export async function exportToSVG(
+  file: ExcalidrawFile,
+  options?: Partial<ExportOptions>
+): Promise<string> {
+  const opts = resolveOptions(file, { format: 'svg', ...options });
+
+  // Ensure DOM polyfills are applied before importing @excalidraw/utils
+  await ensureDOMPolyfill();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const utils = await import('@excalidraw/utils') as any;
+  const exportToSvg = utils.exportToSvg as (opts: {
+    elements: unknown[];
+    appState: Record<string, unknown>;
+    files: Record<string, unknown> | null;
+    exportPadding?: number;
+  }) => Promise<{ outerHTML: string }>;
+
+  const appState = {
+    ...file.appState,
+    exportBackground: opts.exportBackground,
+    viewBackgroundColor: opts.viewBackgroundColor,
+    exportWithDarkMode: opts.exportWithDarkMode,
+    exportEmbedScene: opts.exportEmbedScene,
+  };
+
+  // Suppress noisy @excalidraw/utils font/Path2D warnings during export
+  const originalError = console.error;
+  console.error = (...args: unknown[]) => {
+    const msg = String(args[0] || '');
+    if (msg.includes('font-face') || msg.includes('Path2D')) return;
+    originalError.apply(console, args);
+  };
+
+  try {
+    const svg = await exportToSvg({
+      elements: file.elements as unknown[],
+      appState: appState as Record<string, unknown>,
+      files: (file.files || {}) as Record<string, unknown>,
+      exportPadding: opts.exportPadding,
+    });
+
+    return svg.outerHTML;
+  } finally {
+    console.error = originalError;
+  }
+}
+
+/**
+ * Get the directory containing @excalidraw/utils bundled font assets (TTF files).
+ * These are needed by resvg-js for text rendering since it doesn't
+ * parse @font-face CSS from SVG — fonts must be provided via fontDirs.
+ */
+let cachedFontDir: string | null = null;
+function getExcalidrawFontDir(): string {
+  if (cachedFontDir) return cachedFontDir;
+
+  const require = createRequire(import.meta.url);
+  const utilsEntry = require.resolve('@excalidraw/utils');
+  cachedFontDir = resolve(dirname(utilsEntry), 'assets');
+
+  return cachedFontDir;
+}
+
+/**
+ * Export an Excalidraw file to PNG buffer
+ */
+export async function exportToPNG(
+  file: ExcalidrawFile,
+  options?: Partial<ExportOptions>
+): Promise<Buffer> {
+  const opts = resolveOptions(file, { format: 'png', ...options });
+
+  // First generate SVG
+  const svgString = await exportToSVG(file, opts);
+
+  // Use @resvg/resvg-js to convert SVG → PNG
+  const { Resvg } = await import('@resvg/resvg-js');
+
+  // Parse the SVG to get its natural dimensions
+  const widthMatch = svgString.match(/width="([^"]+)"/);
+  const heightMatch = svgString.match(/height="([^"]+)"/);
+  const naturalWidth = widthMatch ? parseFloat(widthMatch[1]) : 800;
+  const naturalHeight = heightMatch ? parseFloat(heightMatch[1]) : 600;
+
+  const scaledWidth = Math.round(naturalWidth * opts.exportScale);
+
+  // Load Excalidraw font files for text rendering.
+  // resvg-js does NOT parse @font-face CSS from SVG — fonts must be
+  // provided via fontDirs for text to render correctly.
+  const fontDir = getExcalidrawFontDir();
+
+  const resvg = new Resvg(svgString, {
+    fitTo: {
+      mode: 'width' as const,
+      value: scaledWidth,
+    },
+    background: opts.exportBackground ? opts.viewBackgroundColor : undefined,
+    font: {
+      loadSystemFonts: false,
+      fontDirs: [fontDir],
+    },
+  });
+
+  const pngData = resvg.render();
+  const pngBuffer = pngData.asPng();
+
+  return Buffer.from(pngBuffer);
+}
+
+/**
+ * Export an Excalidraw file to the specified format
+ * Returns either an SVG string or a PNG Buffer
+ */
+export async function exportImage(
+  file: ExcalidrawFile,
+  options: ExportOptions
+): Promise<string | Buffer> {
+  if (options.format === 'png') {
+    return exportToPNG(file, options);
+  }
+  return exportToSVG(file, options);
+}
+
+/**
+ * Swap a file path's extension
+ */
+export function swapExtension(filePath: string, newExt: string): string {
+  const lastDot = filePath.lastIndexOf('.');
+  const base = lastDot > 0 ? filePath.substring(0, lastDot) : filePath;
+  return `${base}.${newExt}`;
+}

--- a/src/exporter/image-exporter.ts
+++ b/src/exporter/image-exporter.ts
@@ -70,7 +70,7 @@ function resolveOptions(
 /**
  * Export an Excalidraw file to SVG string
  */
-export async function exportToSVG(
+export async function convertToSVG(
   file: ExcalidrawFile,
   options?: Partial<ExportOptions>
 ): Promise<string> {
@@ -137,14 +137,14 @@ function getExcalidrawFontDir(): string {
 /**
  * Export an Excalidraw file to PNG buffer
  */
-export async function exportToPNG(
+export async function convertToPNG(
   file: ExcalidrawFile,
   options?: Partial<ExportOptions>
 ): Promise<Buffer> {
   const opts = resolveOptions(file, { format: 'png', ...options });
 
   // First generate SVG
-  const svgString = await exportToSVG(file, opts);
+  const svgString = await convertToSVG(file, opts);
 
   // Use @resvg/resvg-js to convert SVG → PNG
   const { Resvg } = await import('@resvg/resvg-js');
@@ -184,14 +184,14 @@ export async function exportToPNG(
  * Export an Excalidraw file to the specified format
  * Returns either an SVG string or a PNG Buffer
  */
-export async function exportImage(
+export async function convertImage(
   file: ExcalidrawFile,
   options: ExportOptions
 ): Promise<string | Buffer> {
   if (options.format === 'png') {
-    return exportToPNG(file, options);
+    return convertToPNG(file, options);
   }
-  return exportToSVG(file, options);
+  return convertToSVG(file, options);
 }
 
 /**

--- a/src/exporter/index.ts
+++ b/src/exporter/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Exporter module - re-exports
+ */
+
+export {
+  exportToSVG,
+  exportToPNG,
+  exportImage,
+  swapExtension,
+  DEFAULT_EXPORT_OPTIONS,
+} from './image-exporter.js';
+
+export type { ExportOptions } from './image-exporter.js';

--- a/src/exporter/index.ts
+++ b/src/exporter/index.ts
@@ -3,9 +3,9 @@
  */
 
 export {
-  exportToSVG,
-  exportToPNG,
-  exportImage,
+  convertToSVG,
+  convertToPNG,
+  convertImage,
   swapExtension,
   DEFAULT_EXPORT_OPTIONS,
 } from './image-exporter.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,10 @@ export { generateExcalidraw, serializeExcalidraw } from './generator/excalidraw-
 // Factory exports (for advanced usage)
 export { createNode, createArrow, createText } from './factory/index.js';
 
+// Exporter exports
+export { exportToSVG, exportToPNG, exportImage, swapExtension } from './exporter/index.js';
+export type { ExportOptions } from './exporter/index.js';
+
 // Default options
 export { DEFAULT_LAYOUT_OPTIONS } from './types/dsl.js';
 export { DEFAULT_APP_STATE, DEFAULT_ELEMENT_STYLE } from './types/excalidraw.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export { generateExcalidraw, serializeExcalidraw } from './generator/excalidraw-
 export { createNode, createArrow, createText } from './factory/index.js';
 
 // Exporter exports
-export { exportToSVG, exportToPNG, exportImage, swapExtension } from './exporter/index.js';
+export { convertToSVG, convertToPNG, convertImage, swapExtension } from './exporter/index.js';
 export type { ExportOptions } from './exporter/index.js';
 
 // Default options

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -3,7 +3,7 @@
  * Provides minimal valid ExcalidrawFile fixtures.
  */
 
-import type { ExcalidrawFile } from '../../../src/types/excalidraw.js';
+import type { ExcalidrawFile } from '../../src/types/excalidraw.js';
 
 /**
  * Create a minimal ExcalidrawFile with a single rectangle element.

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -1,0 +1,250 @@
+/**
+ * Test helpers for exporter tests.
+ * Provides minimal valid ExcalidrawFile fixtures.
+ */
+
+import type { ExcalidrawFile } from '../../../src/types/excalidraw.js';
+
+/**
+ * Create a minimal ExcalidrawFile with a single rectangle element.
+ * Suitable for basic export tests.
+ */
+export function createMinimalFile(): ExcalidrawFile {
+  return {
+    type: 'excalidraw',
+    version: 2,
+    source: 'test',
+    elements: [
+      {
+        id: 'test-rect-1',
+        type: 'rectangle',
+        x: 100,
+        y: 100,
+        width: 200,
+        height: 100,
+        angle: 0,
+        strokeColor: '#1e1e1e',
+        backgroundColor: 'transparent',
+        fillStyle: 'solid',
+        strokeWidth: 2,
+        strokeStyle: 'solid',
+        roughness: 1,
+        opacity: 100,
+        groupIds: [],
+        frameId: null,
+        index: 'a0',
+        roundness: { type: 3 },
+        seed: 12345,
+        version: 1,
+        versionNonce: 1,
+        isDeleted: false,
+        boundElements: null,
+        updated: Date.now(),
+        link: null,
+        locked: false,
+      },
+    ],
+    appState: {
+      gridSize: 20,
+      gridStep: 5,
+      gridModeEnabled: false,
+      viewBackgroundColor: '#ffffff',
+      lockedMultiSelections: {},
+    },
+    files: {},
+  };
+}
+
+/**
+ * Create an ExcalidrawFile with multiple elements:
+ * - A rectangle
+ * - A diamond
+ * - An arrow connecting them
+ * - A text label
+ */
+export function createMultiElementFile(): ExcalidrawFile {
+  return {
+    type: 'excalidraw',
+    version: 2,
+    source: 'test',
+    elements: [
+      {
+        id: 'rect-1',
+        type: 'rectangle',
+        x: 50,
+        y: 50,
+        width: 150,
+        height: 80,
+        angle: 0,
+        strokeColor: '#1e1e1e',
+        backgroundColor: '#a5d8ff',
+        fillStyle: 'solid',
+        strokeWidth: 2,
+        strokeStyle: 'solid',
+        roughness: 1,
+        opacity: 100,
+        groupIds: [],
+        frameId: null,
+        index: 'a0',
+        roundness: { type: 3 },
+        seed: 111,
+        version: 1,
+        versionNonce: 1,
+        isDeleted: false,
+        boundElements: [{ id: 'arrow-1', type: 'arrow' }],
+        updated: Date.now(),
+        link: null,
+        locked: false,
+      },
+      {
+        id: 'diamond-1',
+        type: 'diamond',
+        x: 300,
+        y: 40,
+        width: 120,
+        height: 100,
+        angle: 0,
+        strokeColor: '#e03131',
+        backgroundColor: '#ffc9c9',
+        fillStyle: 'hachure',
+        strokeWidth: 2,
+        strokeStyle: 'solid',
+        roughness: 1,
+        opacity: 100,
+        groupIds: [],
+        frameId: null,
+        index: 'a1',
+        roundness: { type: 2 },
+        seed: 222,
+        version: 1,
+        versionNonce: 2,
+        isDeleted: false,
+        boundElements: [{ id: 'arrow-1', type: 'arrow' }],
+        updated: Date.now(),
+        link: null,
+        locked: false,
+      },
+      {
+        id: 'arrow-1',
+        type: 'arrow',
+        x: 200,
+        y: 90,
+        width: 100,
+        height: 0,
+        angle: 0,
+        strokeColor: '#1e1e1e',
+        backgroundColor: 'transparent',
+        fillStyle: 'solid',
+        strokeWidth: 2,
+        strokeStyle: 'solid',
+        roughness: 1,
+        opacity: 100,
+        groupIds: [],
+        frameId: null,
+        index: 'a2',
+        roundness: { type: 2 },
+        seed: 333,
+        version: 1,
+        versionNonce: 3,
+        isDeleted: false,
+        boundElements: null,
+        updated: Date.now(),
+        link: null,
+        locked: false,
+        points: [
+          [0, 0],
+          [100, 0],
+        ],
+        lastCommittedPoint: null,
+        startBinding: {
+          elementId: 'rect-1',
+          mode: 'orbit',
+          fixedPoint: [1, 0.5],
+        },
+        endBinding: {
+          elementId: 'diamond-1',
+          mode: 'orbit',
+          fixedPoint: [0, 0.5],
+        },
+        startArrowhead: null,
+        endArrowhead: 'arrow',
+        elbowed: false,
+      },
+      {
+        id: 'text-1',
+        type: 'text',
+        x: 80,
+        y: 75,
+        width: 90,
+        height: 25,
+        angle: 0,
+        strokeColor: '#1e1e1e',
+        backgroundColor: 'transparent',
+        fillStyle: 'solid',
+        strokeWidth: 2,
+        strokeStyle: 'solid',
+        roughness: 1,
+        opacity: 100,
+        groupIds: [],
+        frameId: null,
+        index: 'a3',
+        roundness: null,
+        seed: 444,
+        version: 1,
+        versionNonce: 4,
+        isDeleted: false,
+        boundElements: null,
+        updated: Date.now(),
+        link: null,
+        locked: false,
+        text: 'Start Here',
+        fontSize: 20,
+        fontFamily: 5,
+        textAlign: 'center',
+        verticalAlign: 'middle',
+        containerId: null,
+        originalText: 'Start Here',
+        autoResize: true,
+        lineHeight: 1.25,
+      },
+    ],
+    appState: {
+      gridSize: 20,
+      gridStep: 5,
+      gridModeEnabled: false,
+      viewBackgroundColor: '#f0f0f0',
+      lockedMultiSelections: {},
+    },
+    files: {},
+  };
+}
+
+/**
+ * Create an empty ExcalidrawFile with no elements.
+ * Useful for testing edge cases.
+ */
+export function createEmptyFile(): ExcalidrawFile {
+  return {
+    type: 'excalidraw',
+    version: 2,
+    source: 'test',
+    elements: [],
+    appState: {
+      gridSize: 20,
+      gridStep: 5,
+      gridModeEnabled: false,
+      viewBackgroundColor: '#ffffff',
+      lockedMultiSelections: {},
+    },
+    files: {},
+  };
+}
+
+/**
+ * Create an ExcalidrawFile with custom background color.
+ */
+export function createFileWithBackground(color: string): ExcalidrawFile {
+  const file = createMinimalFile();
+  file.appState.viewBackgroundColor = color;
+  return file;
+}

--- a/tests/integration/exporter/cli-export.test.ts
+++ b/tests/integration/exporter/cli-export.test.ts
@@ -160,7 +160,7 @@ describe('CLI export command', () => {
       expect(existsSync(svgFile)).toBe(true);
     }, 60000);
 
-    it('should respect --export-scale in create command', () => {
+    it('should respect --scale in create command', () => {
       const outFile = tmpFile('cli-scale.excalidraw');
 
       runCLI([
@@ -171,7 +171,7 @@ describe('CLI export command', () => {
         outFile,
         '--export-as',
         'png',
-        '--export-scale',
+        '--scale',
         '2',
       ]);
 
@@ -205,7 +205,7 @@ describe('CLI export command', () => {
     }, 60000);
   });
 
-  describe('standalone export command', () => {
+  describe('standalone convert command', () => {
     it('should export existing .excalidraw to SVG', () => {
       // First, write a test .excalidraw file
       const inputFile = tmpFile('export-test.excalidraw');
@@ -213,7 +213,7 @@ describe('CLI export command', () => {
 
       const svgFile = tmpFile('export-test.svg');
 
-      runCLI(['export', inputFile, '-F', 'svg', '-o', svgFile]);
+      runCLI(['convert', inputFile, '--format', 'svg', '-o', svgFile]);
 
       expect(existsSync(svgFile)).toBe(true);
       const svgContent = readFileSync(svgFile, 'utf-8');
@@ -226,7 +226,7 @@ describe('CLI export command', () => {
 
       const pngFile = tmpFile('export-test-png.png');
 
-      runCLI(['export', inputFile, '-F', 'png', '-o', pngFile]);
+      runCLI(['convert', inputFile, '--format', 'png', '-o', pngFile]);
 
       expect(existsSync(pngFile)).toBe(true);
       const pngData = readFileSync(pngFile);
@@ -237,7 +237,7 @@ describe('CLI export command', () => {
       const inputFile = tmpFile('autoname.excalidraw');
       writeFileSync(inputFile, JSON.stringify(createMinimalFile()), 'utf-8');
 
-      runCLI(['export', inputFile, '-F', 'svg']);
+      runCLI(['convert', inputFile, '--format', 'svg']);
 
       const autoSvg = inputFile.replace('.excalidraw', '.svg');
       filesToClean.push(autoSvg);
@@ -251,9 +251,9 @@ describe('CLI export command', () => {
       const svgFile = tmpFile('verbose-test.svg');
 
       const { stdout } = runCLI([
-        'export',
+        'convert',
         inputFile,
-        '-F',
+        '--format',
         'svg',
         '-o',
         svgFile,
@@ -270,7 +270,7 @@ describe('CLI export command', () => {
       writeFileSync(inputFile, JSON.stringify(createMinimalFile()), 'utf-8');
 
       const { stderr } = runCLI(
-        ['export', inputFile, '-F', 'bmp'],
+        ['convert', inputFile, '--format', 'bmp'],
         { expectError: true }
       );
 
@@ -279,7 +279,7 @@ describe('CLI export command', () => {
 
     it('should fail when input file does not exist', () => {
       const { stderr } = runCLI(
-        ['export', 'nonexistent.excalidraw', '-F', 'svg'],
+        ['convert', 'nonexistent.excalidraw', '--format', 'svg'],
         { expectError: true }
       );
 
@@ -291,7 +291,7 @@ describe('CLI export command', () => {
       writeFileSync(inputFile, 'this is not json', 'utf-8');
 
       const { stderr } = runCLI(
-        ['export', inputFile, '-F', 'svg'],
+        ['convert', inputFile, '--format', 'svg'],
         { expectError: true }
       );
 
@@ -305,9 +305,9 @@ describe('CLI export command', () => {
       const svgFile = tmpFile('dark-nobg.svg');
 
       runCLI([
-        'export',
+        'convert',
         inputFile,
-        '-F',
+        '--format',
         'svg',
         '-o',
         svgFile,
@@ -327,13 +327,13 @@ describe('CLI export command', () => {
       const pngFile = tmpFile('scaled.png');
 
       runCLI([
-        'export',
+        'convert',
         inputFile,
-        '-F',
+        '--format',
         'png',
         '-o',
         pngFile,
-        '--export-scale',
+        '--scale',
         '3',
       ]);
 

--- a/tests/integration/exporter/cli-export.test.ts
+++ b/tests/integration/exporter/cli-export.test.ts
@@ -1,3 +1,11 @@
+/**
+ * Integration tests for the CLI export / convert commands.
+ *
+ * Spawns the compiled CLI binary (`dist/cli.js`) in a subprocess and
+ * verifies that `create --export-as` and standalone `convert` produce
+ * valid SVG / PNG output files with the expected options applied.
+ */
+
 import { describe, it, expect, afterEach, beforeAll } from 'vitest';
 import { execFileSync } from 'child_process';
 import { readFileSync, existsSync, unlinkSync, writeFileSync, mkdirSync } from 'fs';
@@ -35,11 +43,15 @@ function runCLI(args: string[], options?: { expectError?: boolean }): {
   }
 }
 
-/**
- * Helper to clean up temporary files after tests.
- */
+/** Accumulator of file paths to delete in the `afterEach` hook. */
 const filesToClean: string[] = [];
 
+/**
+ * Register a temporary file path for automatic cleanup after each test.
+ *
+ * @param name - File name (relative to `TMP_DIR`).
+ * @returns The absolute path to the temporary file.
+ */
 function tmpFile(name: string): string {
   const path = join(TMP_DIR, name);
   filesToClean.push(path);

--- a/tests/integration/exporter/cli-export.test.ts
+++ b/tests/integration/exporter/cli-export.test.ts
@@ -1,9 +1,9 @@
 /**
- * Integration tests for the CLI export / convert commands.
+ * Integration tests for the CLI convert command.
  *
  * Spawns the compiled CLI binary (`dist/cli.js`) in a subprocess and
- * verifies that `create --export-as` and standalone `convert` produce
- * valid SVG / PNG output files with the expected options applied.
+ * verifies that the standalone `convert` command produces valid SVG / PNG
+ * output files with the expected options applied.
  */
 
 import { describe, it, expect, afterEach, beforeAll } from 'vitest';
@@ -77,144 +77,6 @@ describe('CLI export command', () => {
   // Ensure tmp dir exists before tests
   it('should have a working CLI binary', () => {
     expect(existsSync(CLI_PATH)).toBe(true);
-  });
-
-  describe('create command with --export-as', () => {
-    it('should create both .excalidraw and .svg when --export-as svg', () => {
-      const outFile = tmpFile('cli-test.excalidraw');
-
-      runCLI([
-        'create',
-        '--inline',
-        '[A] -> [B]',
-        '-o',
-        outFile,
-        '--export-as',
-        'svg',
-      ]);
-
-      // Should create the .excalidraw file
-      expect(existsSync(outFile)).toBe(true);
-
-      // Should also create the .svg file
-      const svgFile = outFile.replace('.excalidraw', '.svg');
-      filesToClean.push(svgFile);
-      expect(existsSync(svgFile)).toBe(true);
-
-      // Verify SVG content
-      const svgContent = readFileSync(svgFile, 'utf-8');
-      expect(svgContent).toContain('<svg');
-      expect(svgContent).toContain('</svg>');
-    }, 60000);
-
-    it('should create both .excalidraw and .png when --export-as png', () => {
-      const outFile = tmpFile('cli-test-png.excalidraw');
-
-      runCLI([
-        'create',
-        '--inline',
-        '[A] -> [B]',
-        '-o',
-        outFile,
-        '--export-as',
-        'png',
-      ]);
-
-      expect(existsSync(outFile)).toBe(true);
-
-      const pngFile = outFile.replace('.excalidraw', '.png');
-      filesToClean.push(pngFile);
-      expect(existsSync(pngFile)).toBe(true);
-
-      // Verify PNG magic bytes
-      const pngData = readFileSync(pngFile);
-      expect(pngData.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
-    }, 60000);
-
-    it('should respect --dark flag in create command', () => {
-      const outFile = tmpFile('cli-dark.excalidraw');
-
-      runCLI([
-        'create',
-        '--inline',
-        '[A] -> [B]',
-        '-o',
-        outFile,
-        '--export-as',
-        'svg',
-        '--dark',
-      ]);
-
-      const svgFile = outFile.replace('.excalidraw', '.svg');
-      filesToClean.push(svgFile);
-      expect(existsSync(svgFile)).toBe(true);
-
-      const svgContent = readFileSync(svgFile, 'utf-8');
-      expect(svgContent).toContain('<svg');
-    }, 60000);
-
-    it('should respect --no-export-background in create command', () => {
-      const outFile = tmpFile('cli-nobg.excalidraw');
-
-      runCLI([
-        'create',
-        '--inline',
-        '[A] -> [B]',
-        '-o',
-        outFile,
-        '--export-as',
-        'svg',
-        '--no-export-background',
-      ]);
-
-      const svgFile = outFile.replace('.excalidraw', '.svg');
-      filesToClean.push(svgFile);
-      expect(existsSync(svgFile)).toBe(true);
-    }, 60000);
-
-    it('should respect --scale in create command', () => {
-      const outFile = tmpFile('cli-scale.excalidraw');
-
-      runCLI([
-        'create',
-        '--inline',
-        '[A] -> [B]',
-        '-o',
-        outFile,
-        '--export-as',
-        'png',
-        '--scale',
-        '2',
-      ]);
-
-      const pngFile = outFile.replace('.excalidraw', '.png');
-      filesToClean.push(pngFile);
-      expect(existsSync(pngFile)).toBe(true);
-
-      const pngData = readFileSync(pngFile);
-      expect(pngData.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
-      // Scale 2 should produce a larger file
-      expect(pngData.length).toBeGreaterThan(1000);
-    }, 60000);
-
-    it('should fail with invalid --export-as format', () => {
-      const outFile = tmpFile('cli-bad-format.excalidraw');
-
-      const { stderr } = runCLI(
-        [
-          'create',
-          '--inline',
-          '[A] -> [B]',
-          '-o',
-          outFile,
-          '--export-as',
-          'gif',
-        ],
-        { expectError: true }
-      );
-
-      expect(stderr).toContain('--export-as must be "png" or "svg"');
-    }, 60000);
   });
 
   describe('standalone convert command', () => {
@@ -355,51 +217,4 @@ describe('CLI export command', () => {
     }, 60000);
   });
 
-  describe('create command with --export-as and complex DSL', () => {
-    it('should handle decision tree DSL with SVG export', () => {
-      const outFile = tmpFile('complex.excalidraw');
-      const dsl = '(Start) -> {Decision?} -> "yes" -> [End]';
-
-      runCLI([
-        'create',
-        '--inline',
-        dsl,
-        '-o',
-        outFile,
-        '--export-as',
-        'svg',
-      ]);
-
-      const svgFile = outFile.replace('.excalidraw', '.svg');
-      filesToClean.push(svgFile);
-      expect(existsSync(svgFile)).toBe(true);
-
-      const svgContent = readFileSync(svgFile, 'utf-8');
-      expect(svgContent).toContain('<svg');
-    }, 60000);
-
-    it('should handle multi-line DSL from input file with PNG export', () => {
-      const dslFile = tmpFile('flow.dsl');
-      writeFileSync(
-        dslFile,
-        '@direction LR\n[A] -> [B] -> [C]\n[B] -> [D]',
-        'utf-8'
-      );
-
-      const outFile = tmpFile('flow.excalidraw');
-
-      runCLI([
-        'create',
-        dslFile,
-        '-o',
-        outFile,
-        '--export-as',
-        'png',
-      ]);
-
-      const pngFile = outFile.replace('.excalidraw', '.png');
-      filesToClean.push(pngFile);
-      expect(existsSync(pngFile)).toBe(true);
-    }, 60000);
-  });
 });

--- a/tests/integration/exporter/cli-export.test.ts
+++ b/tests/integration/exporter/cli-export.test.ts
@@ -119,7 +119,7 @@ describe('CLI export command', () => {
       expect(pngData.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
     }, 60000);
 
-    it('should respect --dark-mode flag in create command', () => {
+    it('should respect --dark flag in create command', () => {
       const outFile = tmpFile('cli-dark.excalidraw');
 
       runCLI([
@@ -130,7 +130,7 @@ describe('CLI export command', () => {
         outFile,
         '--export-as',
         'svg',
-        '--dark-mode',
+        '--dark',
       ]);
 
       const svgFile = outFile.replace('.excalidraw', '.svg');
@@ -311,7 +311,7 @@ describe('CLI export command', () => {
         'svg',
         '-o',
         svgFile,
-        '--dark-mode',
+        '--dark',
         '--no-export-background',
       ]);
 

--- a/tests/integration/exporter/cli-export.test.ts
+++ b/tests/integration/exporter/cli-export.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect, afterEach, beforeAll } from 'vitest';
+import { execFileSync } from 'child_process';
+import { readFileSync, existsSync, unlinkSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { createMinimalFile } from '../../helpers/fixtures.js';
+
+const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
+const CLI_PATH = join(PROJECT_ROOT, 'dist', 'cli.js');
+const TMP_DIR = join(PROJECT_ROOT, 'tests', 'tmp');
+
+// PNG magic bytes
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+
+/**
+ * Run the CLI with given arguments.
+ * Returns { stdout, stderr } or throws on non-zero exit.
+ */
+function runCLI(args: string[], options?: { expectError?: boolean }): {
+  stdout: string;
+  stderr: string;
+} {
+  try {
+    const stdout = execFileSync('node', [CLI_PATH, ...args], {
+      encoding: 'utf-8',
+      cwd: TMP_DIR,
+      timeout: 60000,
+    });
+    return { stdout, stderr: '' };
+  } catch (error: unknown) {
+    const err = error as { stdout?: string; stderr?: string; status?: number };
+    if (options?.expectError) {
+      return { stdout: err.stdout || '', stderr: err.stderr || '' };
+    }
+    throw error;
+  }
+}
+
+/**
+ * Helper to clean up temporary files after tests.
+ */
+const filesToClean: string[] = [];
+
+function tmpFile(name: string): string {
+  const path = join(TMP_DIR, name);
+  filesToClean.push(path);
+  return path;
+}
+
+beforeAll(() => {
+  mkdirSync(TMP_DIR, { recursive: true });
+});
+
+afterEach(() => {
+  for (const f of filesToClean) {
+    try {
+      if (existsSync(f)) unlinkSync(f);
+    } catch {
+      // ignore
+    }
+  }
+  filesToClean.length = 0;
+});
+
+describe('CLI export command', () => {
+  // Ensure tmp dir exists before tests
+  it('should have a working CLI binary', () => {
+    expect(existsSync(CLI_PATH)).toBe(true);
+  });
+
+  describe('create command with --export-as', () => {
+    it('should create both .excalidraw and .svg when --export-as svg', () => {
+      const outFile = tmpFile('cli-test.excalidraw');
+
+      runCLI([
+        'create',
+        '--inline',
+        '[A] -> [B]',
+        '-o',
+        outFile,
+        '--export-as',
+        'svg',
+      ]);
+
+      // Should create the .excalidraw file
+      expect(existsSync(outFile)).toBe(true);
+
+      // Should also create the .svg file
+      const svgFile = outFile.replace('.excalidraw', '.svg');
+      filesToClean.push(svgFile);
+      expect(existsSync(svgFile)).toBe(true);
+
+      // Verify SVG content
+      const svgContent = readFileSync(svgFile, 'utf-8');
+      expect(svgContent).toContain('<svg');
+      expect(svgContent).toContain('</svg>');
+    }, 60000);
+
+    it('should create both .excalidraw and .png when --export-as png', () => {
+      const outFile = tmpFile('cli-test-png.excalidraw');
+
+      runCLI([
+        'create',
+        '--inline',
+        '[A] -> [B]',
+        '-o',
+        outFile,
+        '--export-as',
+        'png',
+      ]);
+
+      expect(existsSync(outFile)).toBe(true);
+
+      const pngFile = outFile.replace('.excalidraw', '.png');
+      filesToClean.push(pngFile);
+      expect(existsSync(pngFile)).toBe(true);
+
+      // Verify PNG magic bytes
+      const pngData = readFileSync(pngFile);
+      expect(pngData.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
+    }, 60000);
+
+    it('should respect --dark-mode flag in create command', () => {
+      const outFile = tmpFile('cli-dark.excalidraw');
+
+      runCLI([
+        'create',
+        '--inline',
+        '[A] -> [B]',
+        '-o',
+        outFile,
+        '--export-as',
+        'svg',
+        '--dark-mode',
+      ]);
+
+      const svgFile = outFile.replace('.excalidraw', '.svg');
+      filesToClean.push(svgFile);
+      expect(existsSync(svgFile)).toBe(true);
+
+      const svgContent = readFileSync(svgFile, 'utf-8');
+      expect(svgContent).toContain('<svg');
+    }, 60000);
+
+    it('should respect --no-export-background in create command', () => {
+      const outFile = tmpFile('cli-nobg.excalidraw');
+
+      runCLI([
+        'create',
+        '--inline',
+        '[A] -> [B]',
+        '-o',
+        outFile,
+        '--export-as',
+        'svg',
+        '--no-export-background',
+      ]);
+
+      const svgFile = outFile.replace('.excalidraw', '.svg');
+      filesToClean.push(svgFile);
+      expect(existsSync(svgFile)).toBe(true);
+    }, 60000);
+
+    it('should respect --export-scale in create command', () => {
+      const outFile = tmpFile('cli-scale.excalidraw');
+
+      runCLI([
+        'create',
+        '--inline',
+        '[A] -> [B]',
+        '-o',
+        outFile,
+        '--export-as',
+        'png',
+        '--export-scale',
+        '2',
+      ]);
+
+      const pngFile = outFile.replace('.excalidraw', '.png');
+      filesToClean.push(pngFile);
+      expect(existsSync(pngFile)).toBe(true);
+
+      const pngData = readFileSync(pngFile);
+      expect(pngData.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
+      // Scale 2 should produce a larger file
+      expect(pngData.length).toBeGreaterThan(1000);
+    }, 60000);
+
+    it('should fail with invalid --export-as format', () => {
+      const outFile = tmpFile('cli-bad-format.excalidraw');
+
+      const { stderr } = runCLI(
+        [
+          'create',
+          '--inline',
+          '[A] -> [B]',
+          '-o',
+          outFile,
+          '--export-as',
+          'gif',
+        ],
+        { expectError: true }
+      );
+
+      expect(stderr).toContain('--export-as must be "png" or "svg"');
+    }, 60000);
+  });
+
+  describe('standalone export command', () => {
+    it('should export existing .excalidraw to SVG', () => {
+      // First, write a test .excalidraw file
+      const inputFile = tmpFile('export-test.excalidraw');
+      writeFileSync(inputFile, JSON.stringify(createMinimalFile()), 'utf-8');
+
+      const svgFile = tmpFile('export-test.svg');
+
+      runCLI(['export', inputFile, '-F', 'svg', '-o', svgFile]);
+
+      expect(existsSync(svgFile)).toBe(true);
+      const svgContent = readFileSync(svgFile, 'utf-8');
+      expect(svgContent).toContain('<svg');
+    }, 60000);
+
+    it('should export existing .excalidraw to PNG', () => {
+      const inputFile = tmpFile('export-test-png.excalidraw');
+      writeFileSync(inputFile, JSON.stringify(createMinimalFile()), 'utf-8');
+
+      const pngFile = tmpFile('export-test-png.png');
+
+      runCLI(['export', inputFile, '-F', 'png', '-o', pngFile]);
+
+      expect(existsSync(pngFile)).toBe(true);
+      const pngData = readFileSync(pngFile);
+      expect(pngData.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
+    }, 60000);
+
+    it('should auto-name output file from input when -o not provided', () => {
+      const inputFile = tmpFile('autoname.excalidraw');
+      writeFileSync(inputFile, JSON.stringify(createMinimalFile()), 'utf-8');
+
+      runCLI(['export', inputFile, '-F', 'svg']);
+
+      const autoSvg = inputFile.replace('.excalidraw', '.svg');
+      filesToClean.push(autoSvg);
+      expect(existsSync(autoSvg)).toBe(true);
+    }, 60000);
+
+    it('should export with --verbose flag', () => {
+      const inputFile = tmpFile('verbose-test.excalidraw');
+      writeFileSync(inputFile, JSON.stringify(createMinimalFile()), 'utf-8');
+
+      const svgFile = tmpFile('verbose-test.svg');
+
+      const { stdout } = runCLI([
+        'export',
+        inputFile,
+        '-F',
+        'svg',
+        '-o',
+        svgFile,
+        '--verbose',
+      ]);
+
+      expect(stdout).toContain('Input:');
+      expect(stdout).toContain('Elements:');
+      expect(stdout).toContain('Exported:');
+    }, 60000);
+
+    it('should fail with invalid format', () => {
+      const inputFile = tmpFile('bad-format.excalidraw');
+      writeFileSync(inputFile, JSON.stringify(createMinimalFile()), 'utf-8');
+
+      const { stderr } = runCLI(
+        ['export', inputFile, '-F', 'bmp'],
+        { expectError: true }
+      );
+
+      expect(stderr).toContain('--format must be "png" or "svg"');
+    }, 60000);
+
+    it('should fail when input file does not exist', () => {
+      const { stderr } = runCLI(
+        ['export', 'nonexistent.excalidraw', '-F', 'svg'],
+        { expectError: true }
+      );
+
+      expect(stderr.length).toBeGreaterThan(0);
+    }, 60000);
+
+    it('should fail when input is invalid JSON', () => {
+      const inputFile = tmpFile('invalid.excalidraw');
+      writeFileSync(inputFile, 'this is not json', 'utf-8');
+
+      const { stderr } = runCLI(
+        ['export', inputFile, '-F', 'svg'],
+        { expectError: true }
+      );
+
+      expect(stderr.length).toBeGreaterThan(0);
+    }, 60000);
+
+    it('should export with dark mode and no background', () => {
+      const inputFile = tmpFile('dark-nobg.excalidraw');
+      writeFileSync(inputFile, JSON.stringify(createMinimalFile()), 'utf-8');
+
+      const svgFile = tmpFile('dark-nobg.svg');
+
+      runCLI([
+        'export',
+        inputFile,
+        '-F',
+        'svg',
+        '-o',
+        svgFile,
+        '--dark-mode',
+        '--no-export-background',
+      ]);
+
+      expect(existsSync(svgFile)).toBe(true);
+      const svgContent = readFileSync(svgFile, 'utf-8');
+      expect(svgContent).toContain('<svg');
+    }, 60000);
+
+    it('should export PNG with custom scale', () => {
+      const inputFile = tmpFile('scaled.excalidraw');
+      writeFileSync(inputFile, JSON.stringify(createMinimalFile()), 'utf-8');
+
+      const pngFile = tmpFile('scaled.png');
+
+      runCLI([
+        'export',
+        inputFile,
+        '-F',
+        'png',
+        '-o',
+        pngFile,
+        '--export-scale',
+        '3',
+      ]);
+
+      expect(existsSync(pngFile)).toBe(true);
+      const pngData = readFileSync(pngFile);
+      expect(pngData.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
+    }, 60000);
+  });
+
+  describe('create command with --export-as and complex DSL', () => {
+    it('should handle decision tree DSL with SVG export', () => {
+      const outFile = tmpFile('complex.excalidraw');
+      const dsl = '(Start) -> {Decision?} -> "yes" -> [End]';
+
+      runCLI([
+        'create',
+        '--inline',
+        dsl,
+        '-o',
+        outFile,
+        '--export-as',
+        'svg',
+      ]);
+
+      const svgFile = outFile.replace('.excalidraw', '.svg');
+      filesToClean.push(svgFile);
+      expect(existsSync(svgFile)).toBe(true);
+
+      const svgContent = readFileSync(svgFile, 'utf-8');
+      expect(svgContent).toContain('<svg');
+    }, 60000);
+
+    it('should handle multi-line DSL from input file with PNG export', () => {
+      const dslFile = tmpFile('flow.dsl');
+      writeFileSync(
+        dslFile,
+        '@direction LR\n[A] -> [B] -> [C]\n[B] -> [D]',
+        'utf-8'
+      );
+
+      const outFile = tmpFile('flow.excalidraw');
+
+      runCLI([
+        'create',
+        dslFile,
+        '-o',
+        outFile,
+        '--export-as',
+        'png',
+      ]);
+
+      const pngFile = outFile.replace('.excalidraw', '.png');
+      filesToClean.push(pngFile);
+      expect(existsSync(pngFile)).toBe(true);
+    }, 60000);
+  });
+});

--- a/tests/integration/exporter/edge-cases.test.ts
+++ b/tests/integration/exporter/edge-cases.test.ts
@@ -2,9 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import {
-  exportToSVG,
-  exportToPNG,
-  exportImage,
+  convertToSVG,
+  convertToPNG,
+  convertImage,
 } from '../../../src/exporter/image-exporter.js';
 import type { ExcalidrawFile } from '../../../src/types/excalidraw.js';
 import { createMinimalFile, createMultiElementFile } from '../../helpers/fixtures.js';
@@ -12,10 +12,10 @@ import { createMinimalFile, createMultiElementFile } from '../../helpers/fixture
 const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
 
 describe('edge cases and error handling', () => {
-  describe('exportImage routing', () => {
+  describe('convertImage routing', () => {
     it('should route to SVG when format is svg', async () => {
       const file = createMinimalFile();
-      const result = await exportImage(file, { format: 'svg' });
+      const result = await convertImage(file, { format: 'svg' });
 
       expect(typeof result).toBe('string');
       expect((result as string)).toContain('<svg');
@@ -23,7 +23,7 @@ describe('edge cases and error handling', () => {
 
     it('should route to PNG when format is png', async () => {
       const file = createMinimalFile();
-      const result = await exportImage(file, { format: 'png' });
+      const result = await convertImage(file, { format: 'png' });
 
       expect(Buffer.isBuffer(result)).toBe(true);
     }, 30000);
@@ -35,7 +35,7 @@ describe('edge cases and error handling', () => {
       const raw = readFileSync(examplePath, 'utf-8');
       const file: ExcalidrawFile = JSON.parse(raw);
 
-      const svg = await exportToSVG(file);
+      const svg = await convertToSVG(file);
 
       expect(svg).toContain('<svg');
       expect(svg).toContain('</svg>');
@@ -48,7 +48,7 @@ describe('edge cases and error handling', () => {
       const raw = readFileSync(examplePath, 'utf-8');
       const file: ExcalidrawFile = JSON.parse(raw);
 
-      const png = await exportToPNG(file);
+      const png = await convertToPNG(file);
 
       expect(Buffer.isBuffer(png)).toBe(true);
       expect(png.length).toBeGreaterThan(5000);
@@ -65,7 +65,7 @@ describe('edge cases and error handling', () => {
       const file = createMinimalFile();
       file.appState.viewBackgroundColor = '#aabbcc';
 
-      const svg = await exportToSVG(file, {
+      const svg = await convertToSVG(file, {
         viewBackgroundColor: '#112233',
       });
 
@@ -77,7 +77,7 @@ describe('edge cases and error handling', () => {
       const file = createMinimalFile();
       file.appState.viewBackgroundColor = '#aabbcc';
 
-      const svg = await exportToSVG(file);
+      const svg = await convertToSVG(file);
 
       expect(svg).toContain('#aabbcc');
     }, 30000);
@@ -86,7 +86,7 @@ describe('edge cases and error handling', () => {
   describe('combined options', () => {
     it('should handle all options set simultaneously for SVG', async () => {
       const file = createMultiElementFile();
-      const svg = await exportToSVG(file, {
+      const svg = await convertToSVG(file, {
         exportBackground: true,
         viewBackgroundColor: '#ff00ff',
         exportWithDarkMode: true,
@@ -99,7 +99,7 @@ describe('edge cases and error handling', () => {
 
     it('should handle all options set simultaneously for PNG', async () => {
       const file = createMultiElementFile();
-      const png = await exportToPNG(file, {
+      const png = await convertToPNG(file, {
         exportBackground: true,
         viewBackgroundColor: '#00ffff',
         exportWithDarkMode: false,
@@ -116,16 +116,16 @@ describe('edge cases and error handling', () => {
   describe('consistency checks', () => {
     it('should produce identical SVG for same input', async () => {
       const file = createMinimalFile();
-      const svg1 = await exportToSVG(file);
-      const svg2 = await exportToSVG(file);
+      const svg1 = await convertToSVG(file);
+      const svg2 = await convertToSVG(file);
 
       expect(svg1).toBe(svg2);
     }, 30000);
 
     it('should produce identical PNG for same input', async () => {
       const file = createMinimalFile();
-      const png1 = await exportToPNG(file);
-      const png2 = await exportToPNG(file);
+      const png1 = await convertToPNG(file);
+      const png2 = await convertToPNG(file);
 
       expect(png1.equals(png2)).toBe(true);
     }, 30000);
@@ -139,7 +139,7 @@ describe('edge cases and error handling', () => {
 
       // Should still produce valid output (possibly empty-ish)
       try {
-        const svg = await exportToSVG(file);
+        const svg = await convertToSVG(file);
         expect(svg).toContain('<svg');
       } catch {
         // Acceptable if @excalidraw/utils can't handle all-deleted elements
@@ -150,14 +150,14 @@ describe('edge cases and error handling', () => {
   describe('SVG structure validation', () => {
     it('should produce well-formed SVG with namespace', async () => {
       const file = createMinimalFile();
-      const svg = await exportToSVG(file);
+      const svg = await convertToSVG(file);
 
       expect(svg).toContain('xmlns');
     }, 30000);
 
     it('should contain rect/path elements for shapes', async () => {
       const file = createMultiElementFile();
-      const svg = await exportToSVG(file);
+      const svg = await convertToSVG(file);
 
       // The SVG should contain graphical elements
       const hasGraphics =

--- a/tests/integration/exporter/edge-cases.test.ts
+++ b/tests/integration/exporter/edge-cases.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Integration tests for edge cases and error handling in the image exporter.
+ *
+ * Covers format routing, real file exports, option priority, combined options,
+ * consistency (deterministic output), deleted elements, and SVG structure.
+ */
+
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import { join } from 'path';

--- a/tests/integration/exporter/edge-cases.test.ts
+++ b/tests/integration/exporter/edge-cases.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  exportToSVG,
+  exportToPNG,
+  exportImage,
+} from '../../../src/exporter/image-exporter.js';
+import type { ExcalidrawFile } from '../../../src/types/excalidraw.js';
+import { createMinimalFile, createMultiElementFile } from '../../helpers/fixtures.js';
+
+const PROJECT_ROOT = join(import.meta.dirname, '..', '..', '..');
+
+describe('edge cases and error handling', () => {
+  describe('exportImage routing', () => {
+    it('should route to SVG when format is svg', async () => {
+      const file = createMinimalFile();
+      const result = await exportImage(file, { format: 'svg' });
+
+      expect(typeof result).toBe('string');
+      expect((result as string)).toContain('<svg');
+    }, 30000);
+
+    it('should route to PNG when format is png', async () => {
+      const file = createMinimalFile();
+      const result = await exportImage(file, { format: 'png' });
+
+      expect(Buffer.isBuffer(result)).toBe(true);
+    }, 30000);
+  });
+
+  describe('real excalidraw file export', () => {
+    it('should export the example.excalidraw file to SVG', async () => {
+      const examplePath = join(PROJECT_ROOT, 'example.excalidraw');
+      const raw = readFileSync(examplePath, 'utf-8');
+      const file: ExcalidrawFile = JSON.parse(raw);
+
+      const svg = await exportToSVG(file);
+
+      expect(svg).toContain('<svg');
+      expect(svg).toContain('</svg>');
+      // The example file has many elements, so SVG should be substantial
+      expect(svg.length).toBeGreaterThan(1000);
+    }, 30000);
+
+    it('should export the example.excalidraw file to PNG', async () => {
+      const examplePath = join(PROJECT_ROOT, 'example.excalidraw');
+      const raw = readFileSync(examplePath, 'utf-8');
+      const file: ExcalidrawFile = JSON.parse(raw);
+
+      const png = await exportToPNG(file);
+
+      expect(Buffer.isBuffer(png)).toBe(true);
+      expect(png.length).toBeGreaterThan(5000);
+      // Verify PNG magic bytes
+      expect(png[0]).toBe(0x89);
+      expect(png[1]).toBe(0x50);
+      expect(png[2]).toBe(0x4e);
+      expect(png[3]).toBe(0x47);
+    }, 30000);
+  });
+
+  describe('options priority', () => {
+    it('should prefer explicit viewBackgroundColor over appState', async () => {
+      const file = createMinimalFile();
+      file.appState.viewBackgroundColor = '#aabbcc';
+
+      const svg = await exportToSVG(file, {
+        viewBackgroundColor: '#112233',
+      });
+
+      // The explicit option should win
+      expect(svg).toContain('#112233');
+    }, 30000);
+
+    it('should use appState background when no explicit color given', async () => {
+      const file = createMinimalFile();
+      file.appState.viewBackgroundColor = '#aabbcc';
+
+      const svg = await exportToSVG(file);
+
+      expect(svg).toContain('#aabbcc');
+    }, 30000);
+  });
+
+  describe('combined options', () => {
+    it('should handle all options set simultaneously for SVG', async () => {
+      const file = createMultiElementFile();
+      const svg = await exportToSVG(file, {
+        exportBackground: true,
+        viewBackgroundColor: '#ff00ff',
+        exportWithDarkMode: true,
+        exportEmbedScene: true,
+        exportPadding: 50,
+      });
+
+      expect(svg).toContain('<svg');
+    }, 30000);
+
+    it('should handle all options set simultaneously for PNG', async () => {
+      const file = createMultiElementFile();
+      const png = await exportToPNG(file, {
+        exportBackground: true,
+        viewBackgroundColor: '#00ffff',
+        exportWithDarkMode: false,
+        exportEmbedScene: false,
+        exportPadding: 25,
+        exportScale: 2,
+      });
+
+      expect(Buffer.isBuffer(png)).toBe(true);
+      expect(png.length).toBeGreaterThan(100);
+    }, 30000);
+  });
+
+  describe('consistency checks', () => {
+    it('should produce identical SVG for same input', async () => {
+      const file = createMinimalFile();
+      const svg1 = await exportToSVG(file);
+      const svg2 = await exportToSVG(file);
+
+      expect(svg1).toBe(svg2);
+    }, 30000);
+
+    it('should produce identical PNG for same input', async () => {
+      const file = createMinimalFile();
+      const png1 = await exportToPNG(file);
+      const png2 = await exportToPNG(file);
+
+      expect(png1.equals(png2)).toBe(true);
+    }, 30000);
+  });
+
+  describe('file with deleted elements', () => {
+    it('should handle elements marked as deleted', async () => {
+      const file = createMinimalFile();
+      // Mark the element as deleted
+      (file.elements[0] as any).isDeleted = true;
+
+      // Should still produce valid output (possibly empty-ish)
+      try {
+        const svg = await exportToSVG(file);
+        expect(svg).toContain('<svg');
+      } catch {
+        // Acceptable if @excalidraw/utils can't handle all-deleted elements
+      }
+    }, 30000);
+  });
+
+  describe('SVG structure validation', () => {
+    it('should produce well-formed SVG with namespace', async () => {
+      const file = createMinimalFile();
+      const svg = await exportToSVG(file);
+
+      expect(svg).toContain('xmlns');
+    }, 30000);
+
+    it('should contain rect/path elements for shapes', async () => {
+      const file = createMultiElementFile();
+      const svg = await exportToSVG(file);
+
+      // The SVG should contain graphical elements
+      const hasGraphics =
+        svg.includes('<rect') ||
+        svg.includes('<path') ||
+        svg.includes('<g') ||
+        svg.includes('<line');
+      expect(hasGraphics).toBe(true);
+    }, 30000);
+  });
+});

--- a/tests/integration/exporter/edge-cases.test.ts
+++ b/tests/integration/exporter/edge-cases.test.ts
@@ -96,7 +96,7 @@ describe('edge cases and error handling', () => {
       const svg = await convertToSVG(file, {
         exportBackground: true,
         viewBackgroundColor: '#ff00ff',
-        exportWithDarkMode: true,
+        dark: true,
         exportEmbedScene: true,
         exportPadding: 50,
       });
@@ -109,10 +109,10 @@ describe('edge cases and error handling', () => {
       const png = await convertToPNG(file, {
         exportBackground: true,
         viewBackgroundColor: '#00ffff',
-        exportWithDarkMode: false,
+        dark: false,
         exportEmbedScene: false,
         exportPadding: 25,
-        exportScale: 2,
+        scale: 2,
       });
 
       expect(Buffer.isBuffer(png)).toBe(true);

--- a/tests/integration/exporter/edge-cases.test.ts
+++ b/tests/integration/exporter/edge-cases.test.ts
@@ -98,7 +98,7 @@ describe('edge cases and error handling', () => {
         viewBackgroundColor: '#ff00ff',
         dark: true,
         exportEmbedScene: true,
-        exportPadding: 50,
+        padding: 50,
       });
 
       expect(svg).toContain('<svg');
@@ -111,7 +111,7 @@ describe('edge cases and error handling', () => {
         viewBackgroundColor: '#00ffff',
         dark: false,
         exportEmbedScene: false,
-        exportPadding: 25,
+        padding: 25,
         scale: 2,
       });
 

--- a/tests/integration/exporter/png-export.test.ts
+++ b/tests/integration/exporter/png-export.test.ts
@@ -132,7 +132,7 @@ describe('convertToPNG', () => {
   describe('padding', () => {
     it('should produce valid PNG with zero padding', async () => {
       const file = createMinimalFile();
-      const png = await convertToPNG(file, { exportPadding: 0 });
+      const png = await convertToPNG(file, { padding: 0 });
 
       expect(Buffer.isBuffer(png)).toBe(true);
       expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
@@ -140,7 +140,7 @@ describe('convertToPNG', () => {
 
     it('should produce valid PNG with large padding', async () => {
       const file = createMinimalFile();
-      const png = await convertToPNG(file, { exportPadding: 200 });
+      const png = await convertToPNG(file, { padding: 200 });
 
       expect(Buffer.isBuffer(png)).toBe(true);
       expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);

--- a/tests/integration/exporter/png-export.test.ts
+++ b/tests/integration/exporter/png-export.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import { exportToPNG, exportImage } from '../../../src/exporter/image-exporter.js';
+import {
+  createMinimalFile,
+  createMultiElementFile,
+  createFileWithBackground,
+} from '../../helpers/fixtures.js';
+
+// PNG magic bytes: 0x89 0x50 0x4E 0x47 (‰PNG)
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+
+describe('exportToPNG', () => {
+  describe('basic PNG generation', () => {
+    it('should return a Buffer', async () => {
+      const file = createMinimalFile();
+      const png = await exportToPNG(file);
+
+      expect(Buffer.isBuffer(png)).toBe(true);
+    }, 30000);
+
+    it('should produce valid PNG data (magic bytes)', async () => {
+      const file = createMinimalFile();
+      const png = await exportToPNG(file);
+
+      // Check PNG signature
+      expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
+    }, 30000);
+
+    it('should produce non-empty PNG buffer', async () => {
+      const file = createMinimalFile();
+      const png = await exportToPNG(file);
+
+      expect(png.length).toBeGreaterThan(100);
+    }, 30000);
+
+    it('should handle multi-element files', async () => {
+      const file = createMultiElementFile();
+      const png = await exportToPNG(file);
+
+      expect(Buffer.isBuffer(png)).toBe(true);
+      expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
+      expect(png.length).toBeGreaterThan(100);
+    }, 30000);
+  });
+
+  describe('scale factor', () => {
+    it('should produce larger PNG with higher scale', async () => {
+      const file = createMinimalFile();
+      const png1x = await exportToPNG(file, { exportScale: 1 });
+      const png2x = await exportToPNG(file, { exportScale: 2 });
+
+      // 2x scale should produce a larger (more bytes) PNG
+      expect(png2x.length).toBeGreaterThan(png1x.length);
+    }, 30000);
+
+    it('should produce valid PNG at lower scale', async () => {
+      const file = createMinimalFile();
+      const pngHalf = await exportToPNG(file, { exportScale: 0.5 });
+
+      // 0.5x scale should still produce a valid PNG
+      // (Note: at very small sizes, PNG compression overhead can make
+      //  the file not strictly smaller, so we just validate correctness)
+      expect(Buffer.isBuffer(pngHalf)).toBe(true);
+      expect(pngHalf.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
+      expect(pngHalf.length).toBeGreaterThan(0);
+    }, 30000);
+
+    it('should accept fractional scales', async () => {
+      const file = createMinimalFile();
+      const png = await exportToPNG(file, { exportScale: 1.5 });
+
+      expect(Buffer.isBuffer(png)).toBe(true);
+      expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
+    }, 30000);
+  });
+
+  describe('background options', () => {
+    it('should produce valid PNG with background disabled', async () => {
+      const file = createMinimalFile();
+      const png = await exportToPNG(file, { exportBackground: false });
+
+      expect(Buffer.isBuffer(png)).toBe(true);
+      expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
+    }, 30000);
+
+    it('should accept custom background color', async () => {
+      const file = createMinimalFile();
+      const png = await exportToPNG(file, {
+        viewBackgroundColor: '#ff0000',
+        exportBackground: true,
+      });
+
+      expect(Buffer.isBuffer(png)).toBe(true);
+      expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
+    }, 30000);
+
+    it('should respect appState background color', async () => {
+      const file = createFileWithBackground('#00ff00');
+      const png = await exportToPNG(file);
+
+      expect(Buffer.isBuffer(png)).toBe(true);
+      expect(png.length).toBeGreaterThan(100);
+    }, 30000);
+  });
+
+  describe('dark mode', () => {
+    it('should produce valid PNG in dark mode', async () => {
+      const file = createMinimalFile();
+      const png = await exportToPNG(file, { exportWithDarkMode: true });
+
+      expect(Buffer.isBuffer(png)).toBe(true);
+      expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
+    }, 30000);
+
+    it('should produce different output in dark vs light mode', async () => {
+      const file = createMinimalFile();
+      const pngLight = await exportToPNG(file, { exportWithDarkMode: false });
+      const pngDark = await exportToPNG(file, { exportWithDarkMode: true });
+
+      // The buffers should differ
+      expect(pngDark.equals(pngLight)).toBe(false);
+    }, 30000);
+  });
+
+  describe('padding', () => {
+    it('should produce valid PNG with zero padding', async () => {
+      const file = createMinimalFile();
+      const png = await exportToPNG(file, { exportPadding: 0 });
+
+      expect(Buffer.isBuffer(png)).toBe(true);
+      expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
+    }, 30000);
+
+    it('should produce valid PNG with large padding', async () => {
+      const file = createMinimalFile();
+      const png = await exportToPNG(file, { exportPadding: 200 });
+
+      expect(Buffer.isBuffer(png)).toBe(true);
+      expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
+    }, 30000);
+  });
+});
+
+describe('exportImage with format=png', () => {
+  it('should return Buffer for PNG format', async () => {
+    const file = createMinimalFile();
+    const result = await exportImage(file, { format: 'png' });
+
+    expect(Buffer.isBuffer(result)).toBe(true);
+  }, 30000);
+
+  it('should produce valid PNG via exportImage', async () => {
+    const file = createMinimalFile();
+    const result = await exportImage(file, { format: 'png' }) as Buffer;
+
+    expect(result.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
+  }, 30000);
+
+  it('should pass through scale option', async () => {
+    const file = createMinimalFile();
+    const result1x = await exportImage(file, {
+      format: 'png',
+      exportScale: 1,
+    }) as Buffer;
+    const result3x = await exportImage(file, {
+      format: 'png',
+      exportScale: 3,
+    }) as Buffer;
+
+    expect(result3x.length).toBeGreaterThan(result1x.length);
+  }, 30000);
+});

--- a/tests/integration/exporter/png-export.test.ts
+++ b/tests/integration/exporter/png-export.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Integration tests for PNG export.
+ *
+ * Validates that {@link convertToPNG} produces valid PNG buffers and
+ * that scale, background, dark-mode, and padding options behave correctly.
+ */
+
 import { describe, it, expect } from 'vitest';
 import { convertToPNG, convertImage } from '../../../src/exporter/image-exporter.js';
 import {

--- a/tests/integration/exporter/png-export.test.ts
+++ b/tests/integration/exporter/png-export.test.ts
@@ -53,8 +53,8 @@ describe('convertToPNG', () => {
   describe('scale factor', () => {
     it('should produce larger PNG with higher scale', async () => {
       const file = createMinimalFile();
-      const png1x = await convertToPNG(file, { exportScale: 1 });
-      const png2x = await convertToPNG(file, { exportScale: 2 });
+      const png1x = await convertToPNG(file, { scale: 1 });
+      const png2x = await convertToPNG(file, { scale: 2 });
 
       // 2x scale should produce a larger (more bytes) PNG
       expect(png2x.length).toBeGreaterThan(png1x.length);
@@ -62,7 +62,7 @@ describe('convertToPNG', () => {
 
     it('should produce valid PNG at lower scale', async () => {
       const file = createMinimalFile();
-      const pngHalf = await convertToPNG(file, { exportScale: 0.5 });
+      const pngHalf = await convertToPNG(file, { scale: 0.5 });
 
       // 0.5x scale should still produce a valid PNG
       // (Note: at very small sizes, PNG compression overhead can make
@@ -74,7 +74,7 @@ describe('convertToPNG', () => {
 
     it('should accept fractional scales', async () => {
       const file = createMinimalFile();
-      const png = await convertToPNG(file, { exportScale: 1.5 });
+      const png = await convertToPNG(file, { scale: 1.5 });
 
       expect(Buffer.isBuffer(png)).toBe(true);
       expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
@@ -113,7 +113,7 @@ describe('convertToPNG', () => {
   describe('dark mode', () => {
     it('should produce valid PNG in dark mode', async () => {
       const file = createMinimalFile();
-      const png = await convertToPNG(file, { exportWithDarkMode: true });
+      const png = await convertToPNG(file, { dark: true });
 
       expect(Buffer.isBuffer(png)).toBe(true);
       expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
@@ -121,8 +121,8 @@ describe('convertToPNG', () => {
 
     it('should produce different output in dark vs light mode', async () => {
       const file = createMinimalFile();
-      const pngLight = await convertToPNG(file, { exportWithDarkMode: false });
-      const pngDark = await convertToPNG(file, { exportWithDarkMode: true });
+      const pngLight = await convertToPNG(file, { dark: false });
+      const pngDark = await convertToPNG(file, { dark: true });
 
       // The buffers should differ
       expect(pngDark.equals(pngLight)).toBe(false);
@@ -167,11 +167,11 @@ describe('convertImage with format=png', () => {
     const file = createMinimalFile();
     const result1x = await convertImage(file, {
       format: 'png',
-      exportScale: 1,
+      scale: 1,
     }) as Buffer;
     const result3x = await convertImage(file, {
       format: 'png',
-      exportScale: 3,
+      scale: 3,
     }) as Buffer;
 
     expect(result3x.length).toBeGreaterThan(result1x.length);

--- a/tests/integration/exporter/png-export.test.ts
+++ b/tests/integration/exporter/png-export.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { exportToPNG, exportImage } from '../../../src/exporter/image-exporter.js';
+import { convertToPNG, convertImage } from '../../../src/exporter/image-exporter.js';
 import {
   createMinimalFile,
   createMultiElementFile,
@@ -9,18 +9,18 @@ import {
 // PNG magic bytes: 0x89 0x50 0x4E 0x47 (‰PNG)
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
 
-describe('exportToPNG', () => {
+describe('convertToPNG', () => {
   describe('basic PNG generation', () => {
     it('should return a Buffer', async () => {
       const file = createMinimalFile();
-      const png = await exportToPNG(file);
+      const png = await convertToPNG(file);
 
       expect(Buffer.isBuffer(png)).toBe(true);
     }, 30000);
 
     it('should produce valid PNG data (magic bytes)', async () => {
       const file = createMinimalFile();
-      const png = await exportToPNG(file);
+      const png = await convertToPNG(file);
 
       // Check PNG signature
       expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
@@ -28,14 +28,14 @@ describe('exportToPNG', () => {
 
     it('should produce non-empty PNG buffer', async () => {
       const file = createMinimalFile();
-      const png = await exportToPNG(file);
+      const png = await convertToPNG(file);
 
       expect(png.length).toBeGreaterThan(100);
     }, 30000);
 
     it('should handle multi-element files', async () => {
       const file = createMultiElementFile();
-      const png = await exportToPNG(file);
+      const png = await convertToPNG(file);
 
       expect(Buffer.isBuffer(png)).toBe(true);
       expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
@@ -46,8 +46,8 @@ describe('exportToPNG', () => {
   describe('scale factor', () => {
     it('should produce larger PNG with higher scale', async () => {
       const file = createMinimalFile();
-      const png1x = await exportToPNG(file, { exportScale: 1 });
-      const png2x = await exportToPNG(file, { exportScale: 2 });
+      const png1x = await convertToPNG(file, { exportScale: 1 });
+      const png2x = await convertToPNG(file, { exportScale: 2 });
 
       // 2x scale should produce a larger (more bytes) PNG
       expect(png2x.length).toBeGreaterThan(png1x.length);
@@ -55,7 +55,7 @@ describe('exportToPNG', () => {
 
     it('should produce valid PNG at lower scale', async () => {
       const file = createMinimalFile();
-      const pngHalf = await exportToPNG(file, { exportScale: 0.5 });
+      const pngHalf = await convertToPNG(file, { exportScale: 0.5 });
 
       // 0.5x scale should still produce a valid PNG
       // (Note: at very small sizes, PNG compression overhead can make
@@ -67,7 +67,7 @@ describe('exportToPNG', () => {
 
     it('should accept fractional scales', async () => {
       const file = createMinimalFile();
-      const png = await exportToPNG(file, { exportScale: 1.5 });
+      const png = await convertToPNG(file, { exportScale: 1.5 });
 
       expect(Buffer.isBuffer(png)).toBe(true);
       expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
@@ -77,7 +77,7 @@ describe('exportToPNG', () => {
   describe('background options', () => {
     it('should produce valid PNG with background disabled', async () => {
       const file = createMinimalFile();
-      const png = await exportToPNG(file, { exportBackground: false });
+      const png = await convertToPNG(file, { exportBackground: false });
 
       expect(Buffer.isBuffer(png)).toBe(true);
       expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
@@ -85,7 +85,7 @@ describe('exportToPNG', () => {
 
     it('should accept custom background color', async () => {
       const file = createMinimalFile();
-      const png = await exportToPNG(file, {
+      const png = await convertToPNG(file, {
         viewBackgroundColor: '#ff0000',
         exportBackground: true,
       });
@@ -96,7 +96,7 @@ describe('exportToPNG', () => {
 
     it('should respect appState background color', async () => {
       const file = createFileWithBackground('#00ff00');
-      const png = await exportToPNG(file);
+      const png = await convertToPNG(file);
 
       expect(Buffer.isBuffer(png)).toBe(true);
       expect(png.length).toBeGreaterThan(100);
@@ -106,7 +106,7 @@ describe('exportToPNG', () => {
   describe('dark mode', () => {
     it('should produce valid PNG in dark mode', async () => {
       const file = createMinimalFile();
-      const png = await exportToPNG(file, { exportWithDarkMode: true });
+      const png = await convertToPNG(file, { exportWithDarkMode: true });
 
       expect(Buffer.isBuffer(png)).toBe(true);
       expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
@@ -114,8 +114,8 @@ describe('exportToPNG', () => {
 
     it('should produce different output in dark vs light mode', async () => {
       const file = createMinimalFile();
-      const pngLight = await exportToPNG(file, { exportWithDarkMode: false });
-      const pngDark = await exportToPNG(file, { exportWithDarkMode: true });
+      const pngLight = await convertToPNG(file, { exportWithDarkMode: false });
+      const pngDark = await convertToPNG(file, { exportWithDarkMode: true });
 
       // The buffers should differ
       expect(pngDark.equals(pngLight)).toBe(false);
@@ -125,7 +125,7 @@ describe('exportToPNG', () => {
   describe('padding', () => {
     it('should produce valid PNG with zero padding', async () => {
       const file = createMinimalFile();
-      const png = await exportToPNG(file, { exportPadding: 0 });
+      const png = await convertToPNG(file, { exportPadding: 0 });
 
       expect(Buffer.isBuffer(png)).toBe(true);
       expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
@@ -133,7 +133,7 @@ describe('exportToPNG', () => {
 
     it('should produce valid PNG with large padding', async () => {
       const file = createMinimalFile();
-      const png = await exportToPNG(file, { exportPadding: 200 });
+      const png = await convertToPNG(file, { exportPadding: 200 });
 
       expect(Buffer.isBuffer(png)).toBe(true);
       expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
@@ -141,28 +141,28 @@ describe('exportToPNG', () => {
   });
 });
 
-describe('exportImage with format=png', () => {
+describe('convertImage with format=png', () => {
   it('should return Buffer for PNG format', async () => {
     const file = createMinimalFile();
-    const result = await exportImage(file, { format: 'png' });
+    const result = await convertImage(file, { format: 'png' });
 
     expect(Buffer.isBuffer(result)).toBe(true);
   }, 30000);
 
-  it('should produce valid PNG via exportImage', async () => {
+  it('should produce valid PNG via convertImage', async () => {
     const file = createMinimalFile();
-    const result = await exportImage(file, { format: 'png' }) as Buffer;
+    const result = await convertImage(file, { format: 'png' }) as Buffer;
 
     expect(result.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
   }, 30000);
 
   it('should pass through scale option', async () => {
     const file = createMinimalFile();
-    const result1x = await exportImage(file, {
+    const result1x = await convertImage(file, {
       format: 'png',
       exportScale: 1,
     }) as Buffer;
-    const result3x = await exportImage(file, {
+    const result3x = await convertImage(file, {
       format: 'png',
       exportScale: 3,
     }) as Buffer;

--- a/tests/integration/exporter/svg-export.test.ts
+++ b/tests/integration/exporter/svg-export.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest';
+import { exportToSVG, exportImage } from '../../../src/exporter/image-exporter.js';
+import {
+  createMinimalFile,
+  createMultiElementFile,
+  createEmptyFile,
+  createFileWithBackground,
+} from '../../helpers/fixtures.js';
+
+describe('exportToSVG', () => {
+  describe('basic SVG generation', () => {
+    it('should return a valid SVG string for a minimal file', async () => {
+      const file = createMinimalFile();
+      const svg = await exportToSVG(file);
+
+      expect(svg).toBeTypeOf('string');
+      expect(svg).toContain('<svg');
+      expect(svg).toContain('</svg>');
+    }, 30000);
+
+    it('should produce SVG with width and height attributes', async () => {
+      const file = createMinimalFile();
+      const svg = await exportToSVG(file);
+
+      expect(svg).toMatch(/width="[\d.]+"/);
+      expect(svg).toMatch(/height="[\d.]+"/);
+    }, 30000);
+
+    it('should produce SVG with a viewBox attribute', async () => {
+      const file = createMinimalFile();
+      const svg = await exportToSVG(file);
+
+      expect(svg).toMatch(/viewBox="[^"]+"/);
+    }, 30000);
+
+    it('should handle multi-element files', async () => {
+      const file = createMultiElementFile();
+      const svg = await exportToSVG(file);
+
+      expect(svg).toBeTypeOf('string');
+      expect(svg).toContain('<svg');
+      expect(svg.length).toBeGreaterThan(100);
+    }, 30000);
+  });
+
+  describe('background options', () => {
+    it('should include background by default', async () => {
+      const file = createMinimalFile();
+      const svg = await exportToSVG(file);
+
+      // Default background is #ffffff
+      expect(svg).toContain('#ffffff');
+    }, 30000);
+
+    it('should respect custom background color from appState', async () => {
+      const file = createFileWithBackground('#ff6600');
+      const svg = await exportToSVG(file);
+
+      expect(svg).toContain('#ff6600');
+    }, 30000);
+
+    it('should respect viewBackgroundColor option override', async () => {
+      const file = createMinimalFile();
+      const svg = await exportToSVG(file, {
+        viewBackgroundColor: '#00cc00',
+      });
+
+      expect(svg).toContain('#00cc00');
+    }, 30000);
+
+    it('should exclude background when exportBackground is false', async () => {
+      const file = createMinimalFile();
+      const svgWithBg = await exportToSVG(file, { exportBackground: true });
+      const svgWithoutBg = await exportToSVG(file, { exportBackground: false });
+
+      // Without background, the SVG may differ (no rect fill for background)
+      // At minimum, both should be valid SVGs
+      expect(svgWithBg).toContain('<svg');
+      expect(svgWithoutBg).toContain('<svg');
+    }, 30000);
+  });
+
+  describe('dark mode', () => {
+    it('should produce different SVG in dark mode', async () => {
+      const file = createMinimalFile();
+      const lightSvg = await exportToSVG(file, { exportWithDarkMode: false });
+      const darkSvg = await exportToSVG(file, { exportWithDarkMode: true });
+
+      // Both should be valid
+      expect(lightSvg).toContain('<svg');
+      expect(darkSvg).toContain('<svg');
+
+      // Dark mode typically changes the theme class or colors
+      // They should differ in some way
+      expect(darkSvg).not.toBe(lightSvg);
+    }, 30000);
+  });
+
+  describe('padding', () => {
+    it('should accept custom padding values', async () => {
+      const file = createMinimalFile();
+
+      // These should not throw
+      const svg0 = await exportToSVG(file, { exportPadding: 0 });
+      const svg50 = await exportToSVG(file, { exportPadding: 50 });
+
+      expect(svg0).toContain('<svg');
+      expect(svg50).toContain('<svg');
+    }, 30000);
+
+    it('should produce wider SVG with larger padding', async () => {
+      const file = createMinimalFile();
+      const svgSmallPad = await exportToSVG(file, { exportPadding: 5 });
+      const svgLargePad = await exportToSVG(file, { exportPadding: 100 });
+
+      // Extract width values
+      const widthSmall = parseFloat(svgSmallPad.match(/width="([\d.]+)"/)?.[1] || '0');
+      const widthLarge = parseFloat(svgLargePad.match(/width="([\d.]+)"/)?.[1] || '0');
+
+      // Larger padding should produce larger SVG dimensions
+      expect(widthLarge).toBeGreaterThan(widthSmall);
+    }, 30000);
+  });
+
+  describe('empty files', () => {
+    it('should handle empty element array without crashing', async () => {
+      const file = createEmptyFile();
+
+      // Should not throw - may produce empty or minimal SVG
+      try {
+        const svg = await exportToSVG(file);
+        expect(svg).toBeTypeOf('string');
+      } catch (error) {
+        // Some versions of @excalidraw/utils may throw on empty elements
+        // That's acceptable behavior
+        expect(error).toBeDefined();
+      }
+    }, 30000);
+  });
+});
+
+describe('exportImage with format=svg', () => {
+  it('should return string for SVG format', async () => {
+    const file = createMinimalFile();
+    const result = await exportImage(file, { format: 'svg' });
+
+    expect(result).toBeTypeOf('string');
+    expect(result as string).toContain('<svg');
+  }, 30000);
+
+  it('should pass through all options to SVG export', async () => {
+    const file = createMinimalFile();
+    const result = await exportImage(file, {
+      format: 'svg',
+      exportBackground: false,
+      exportWithDarkMode: true,
+      exportPadding: 20,
+    });
+
+    expect(result).toBeTypeOf('string');
+    expect(result as string).toContain('<svg');
+  }, 30000);
+});

--- a/tests/integration/exporter/svg-export.test.ts
+++ b/tests/integration/exporter/svg-export.test.ts
@@ -90,8 +90,8 @@ describe('convertToSVG', () => {
   describe('dark mode', () => {
     it('should produce different SVG in dark mode', async () => {
       const file = createMinimalFile();
-      const lightSvg = await convertToSVG(file, { exportWithDarkMode: false });
-      const darkSvg = await convertToSVG(file, { exportWithDarkMode: true });
+      const lightSvg = await convertToSVG(file, { dark: false });
+      const darkSvg = await convertToSVG(file, { dark: true });
 
       // Both should be valid
       expect(lightSvg).toContain('<svg');
@@ -160,7 +160,7 @@ describe('convertImage with format=svg', () => {
     const result = await convertImage(file, {
       format: 'svg',
       exportBackground: false,
-      exportWithDarkMode: true,
+      dark: true,
       exportPadding: 20,
     });
 

--- a/tests/integration/exporter/svg-export.test.ts
+++ b/tests/integration/exporter/svg-export.test.ts
@@ -108,8 +108,8 @@ describe('convertToSVG', () => {
       const file = createMinimalFile();
 
       // These should not throw
-      const svg0 = await convertToSVG(file, { exportPadding: 0 });
-      const svg50 = await convertToSVG(file, { exportPadding: 50 });
+      const svg0 = await convertToSVG(file, { padding: 0 });
+      const svg50 = await convertToSVG(file, { padding: 50 });
 
       expect(svg0).toContain('<svg');
       expect(svg50).toContain('<svg');
@@ -117,8 +117,8 @@ describe('convertToSVG', () => {
 
     it('should produce wider SVG with larger padding', async () => {
       const file = createMinimalFile();
-      const svgSmallPad = await convertToSVG(file, { exportPadding: 5 });
-      const svgLargePad = await convertToSVG(file, { exportPadding: 100 });
+      const svgSmallPad = await convertToSVG(file, { padding: 5 });
+      const svgLargePad = await convertToSVG(file, { padding: 100 });
 
       // Extract width values
       const widthSmall = parseFloat(svgSmallPad.match(/width="([\d.]+)"/)?.[1] || '0');
@@ -161,7 +161,7 @@ describe('convertImage with format=svg', () => {
       format: 'svg',
       exportBackground: false,
       dark: true,
-      exportPadding: 20,
+      padding: 20,
     });
 
     expect(result).toBeTypeOf('string');

--- a/tests/integration/exporter/svg-export.test.ts
+++ b/tests/integration/exporter/svg-export.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { exportToSVG, exportImage } from '../../../src/exporter/image-exporter.js';
+import { convertToSVG, convertImage } from '../../../src/exporter/image-exporter.js';
 import {
   createMinimalFile,
   createMultiElementFile,
@@ -7,11 +7,11 @@ import {
   createFileWithBackground,
 } from '../../helpers/fixtures.js';
 
-describe('exportToSVG', () => {
+describe('convertToSVG', () => {
   describe('basic SVG generation', () => {
     it('should return a valid SVG string for a minimal file', async () => {
       const file = createMinimalFile();
-      const svg = await exportToSVG(file);
+      const svg = await convertToSVG(file);
 
       expect(svg).toBeTypeOf('string');
       expect(svg).toContain('<svg');
@@ -20,7 +20,7 @@ describe('exportToSVG', () => {
 
     it('should produce SVG with width and height attributes', async () => {
       const file = createMinimalFile();
-      const svg = await exportToSVG(file);
+      const svg = await convertToSVG(file);
 
       expect(svg).toMatch(/width="[\d.]+"/);
       expect(svg).toMatch(/height="[\d.]+"/);
@@ -28,14 +28,14 @@ describe('exportToSVG', () => {
 
     it('should produce SVG with a viewBox attribute', async () => {
       const file = createMinimalFile();
-      const svg = await exportToSVG(file);
+      const svg = await convertToSVG(file);
 
       expect(svg).toMatch(/viewBox="[^"]+"/);
     }, 30000);
 
     it('should handle multi-element files', async () => {
       const file = createMultiElementFile();
-      const svg = await exportToSVG(file);
+      const svg = await convertToSVG(file);
 
       expect(svg).toBeTypeOf('string');
       expect(svg).toContain('<svg');
@@ -46,7 +46,7 @@ describe('exportToSVG', () => {
   describe('background options', () => {
     it('should include background by default', async () => {
       const file = createMinimalFile();
-      const svg = await exportToSVG(file);
+      const svg = await convertToSVG(file);
 
       // Default background is #ffffff
       expect(svg).toContain('#ffffff');
@@ -54,14 +54,14 @@ describe('exportToSVG', () => {
 
     it('should respect custom background color from appState', async () => {
       const file = createFileWithBackground('#ff6600');
-      const svg = await exportToSVG(file);
+      const svg = await convertToSVG(file);
 
       expect(svg).toContain('#ff6600');
     }, 30000);
 
     it('should respect viewBackgroundColor option override', async () => {
       const file = createMinimalFile();
-      const svg = await exportToSVG(file, {
+      const svg = await convertToSVG(file, {
         viewBackgroundColor: '#00cc00',
       });
 
@@ -70,8 +70,8 @@ describe('exportToSVG', () => {
 
     it('should exclude background when exportBackground is false', async () => {
       const file = createMinimalFile();
-      const svgWithBg = await exportToSVG(file, { exportBackground: true });
-      const svgWithoutBg = await exportToSVG(file, { exportBackground: false });
+      const svgWithBg = await convertToSVG(file, { exportBackground: true });
+      const svgWithoutBg = await convertToSVG(file, { exportBackground: false });
 
       // Without background, the SVG may differ (no rect fill for background)
       // At minimum, both should be valid SVGs
@@ -83,8 +83,8 @@ describe('exportToSVG', () => {
   describe('dark mode', () => {
     it('should produce different SVG in dark mode', async () => {
       const file = createMinimalFile();
-      const lightSvg = await exportToSVG(file, { exportWithDarkMode: false });
-      const darkSvg = await exportToSVG(file, { exportWithDarkMode: true });
+      const lightSvg = await convertToSVG(file, { exportWithDarkMode: false });
+      const darkSvg = await convertToSVG(file, { exportWithDarkMode: true });
 
       // Both should be valid
       expect(lightSvg).toContain('<svg');
@@ -101,8 +101,8 @@ describe('exportToSVG', () => {
       const file = createMinimalFile();
 
       // These should not throw
-      const svg0 = await exportToSVG(file, { exportPadding: 0 });
-      const svg50 = await exportToSVG(file, { exportPadding: 50 });
+      const svg0 = await convertToSVG(file, { exportPadding: 0 });
+      const svg50 = await convertToSVG(file, { exportPadding: 50 });
 
       expect(svg0).toContain('<svg');
       expect(svg50).toContain('<svg');
@@ -110,8 +110,8 @@ describe('exportToSVG', () => {
 
     it('should produce wider SVG with larger padding', async () => {
       const file = createMinimalFile();
-      const svgSmallPad = await exportToSVG(file, { exportPadding: 5 });
-      const svgLargePad = await exportToSVG(file, { exportPadding: 100 });
+      const svgSmallPad = await convertToSVG(file, { exportPadding: 5 });
+      const svgLargePad = await convertToSVG(file, { exportPadding: 100 });
 
       // Extract width values
       const widthSmall = parseFloat(svgSmallPad.match(/width="([\d.]+)"/)?.[1] || '0');
@@ -128,7 +128,7 @@ describe('exportToSVG', () => {
 
       // Should not throw - may produce empty or minimal SVG
       try {
-        const svg = await exportToSVG(file);
+        const svg = await convertToSVG(file);
         expect(svg).toBeTypeOf('string');
       } catch (error) {
         // Some versions of @excalidraw/utils may throw on empty elements
@@ -139,10 +139,10 @@ describe('exportToSVG', () => {
   });
 });
 
-describe('exportImage with format=svg', () => {
+describe('convertImage with format=svg', () => {
   it('should return string for SVG format', async () => {
     const file = createMinimalFile();
-    const result = await exportImage(file, { format: 'svg' });
+    const result = await convertImage(file, { format: 'svg' });
 
     expect(result).toBeTypeOf('string');
     expect(result as string).toContain('<svg');
@@ -150,7 +150,7 @@ describe('exportImage with format=svg', () => {
 
   it('should pass through all options to SVG export', async () => {
     const file = createMinimalFile();
-    const result = await exportImage(file, {
+    const result = await convertImage(file, {
       format: 'svg',
       exportBackground: false,
       exportWithDarkMode: true,

--- a/tests/integration/exporter/svg-export.test.ts
+++ b/tests/integration/exporter/svg-export.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Integration tests for SVG export.
+ *
+ * Validates that {@link convertToSVG} produces well-formed SVG strings
+ * and that background, dark-mode, and padding options are applied correctly.
+ */
+
 import { describe, it, expect } from 'vitest';
 import { convertToSVG, convertImage } from '../../../src/exporter/image-exporter.js';
 import {

--- a/tests/unit/exporter/export-options.test.ts
+++ b/tests/unit/exporter/export-options.test.ts
@@ -31,7 +31,7 @@ describe('DEFAULT_EXPORT_OPTIONS', () => {
   });
 
   it('should have 10px padding by default', () => {
-    expect(DEFAULT_EXPORT_OPTIONS.exportPadding).toBe(10);
+    expect(DEFAULT_EXPORT_OPTIONS.padding).toBe(10);
   });
 
   it('should have scale 1 by default', () => {
@@ -46,7 +46,7 @@ describe('DEFAULT_EXPORT_OPTIONS', () => {
       'viewBackgroundColor',
       'dark',
       'exportEmbedScene',
-      'exportPadding',
+      'padding',
       'scale',
     ];
     for (const key of keys) {
@@ -74,7 +74,7 @@ describe('ExportOptions type', () => {
       viewBackgroundColor: '#000000',
       dark: true,
       exportEmbedScene: true,
-      exportPadding: 20,
+      padding: 20,
       scale: 2,
     };
     expect(opts.format).toBe('png');
@@ -82,7 +82,7 @@ describe('ExportOptions type', () => {
     expect(opts.viewBackgroundColor).toBe('#000000');
     expect(opts.dark).toBe(true);
     expect(opts.exportEmbedScene).toBe(true);
-    expect(opts.exportPadding).toBe(20);
+    expect(opts.padding).toBe(20);
     expect(opts.scale).toBe(2);
   });
 });

--- a/tests/unit/exporter/export-options.test.ts
+++ b/tests/unit/exporter/export-options.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for {@link DEFAULT_EXPORT_OPTIONS} and the {@link ExportOptions} type.
+ *
+ * Ensures the default values are sensible and that the type allows both
+ * minimal (format-only) and fully-specified option objects.
+ */
+
 import { describe, it, expect } from 'vitest';
 import { DEFAULT_EXPORT_OPTIONS } from '../../../src/exporter/image-exporter.js';
 import type { ExportOptions } from '../../../src/exporter/image-exporter.js';

--- a/tests/unit/exporter/export-options.test.ts
+++ b/tests/unit/exporter/export-options.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { DEFAULT_EXPORT_OPTIONS } from '../../../src/exporter/image-exporter.js';
+import type { ExportOptions } from '../../../src/exporter/image-exporter.js';
+
+describe('DEFAULT_EXPORT_OPTIONS', () => {
+  it('should have svg as default format', () => {
+    expect(DEFAULT_EXPORT_OPTIONS.format).toBe('svg');
+  });
+
+  it('should have exportBackground true by default', () => {
+    expect(DEFAULT_EXPORT_OPTIONS.exportBackground).toBe(true);
+  });
+
+  it('should have white as default background color', () => {
+    expect(DEFAULT_EXPORT_OPTIONS.viewBackgroundColor).toBe('#ffffff');
+  });
+
+  it('should have dark mode disabled by default', () => {
+    expect(DEFAULT_EXPORT_OPTIONS.exportWithDarkMode).toBe(false);
+  });
+
+  it('should have embed scene disabled by default', () => {
+    expect(DEFAULT_EXPORT_OPTIONS.exportEmbedScene).toBe(false);
+  });
+
+  it('should have 10px padding by default', () => {
+    expect(DEFAULT_EXPORT_OPTIONS.exportPadding).toBe(10);
+  });
+
+  it('should have scale 1 by default', () => {
+    expect(DEFAULT_EXPORT_OPTIONS.exportScale).toBe(1);
+  });
+
+  it('should have all required properties', () => {
+    // Ensure no properties are undefined
+    const keys: (keyof Required<ExportOptions>)[] = [
+      'format',
+      'exportBackground',
+      'viewBackgroundColor',
+      'exportWithDarkMode',
+      'exportEmbedScene',
+      'exportPadding',
+      'exportScale',
+    ];
+    for (const key of keys) {
+      expect(DEFAULT_EXPORT_OPTIONS[key]).toBeDefined();
+    }
+  });
+});
+
+describe('ExportOptions type', () => {
+  it('should allow minimal options with only format', () => {
+    const opts: ExportOptions = { format: 'svg' };
+    expect(opts.format).toBe('svg');
+    expect(opts.exportBackground).toBeUndefined();
+  });
+
+  it('should allow png format', () => {
+    const opts: ExportOptions = { format: 'png' };
+    expect(opts.format).toBe('png');
+  });
+
+  it('should allow full options', () => {
+    const opts: ExportOptions = {
+      format: 'png',
+      exportBackground: false,
+      viewBackgroundColor: '#000000',
+      exportWithDarkMode: true,
+      exportEmbedScene: true,
+      exportPadding: 20,
+      exportScale: 2,
+    };
+    expect(opts.format).toBe('png');
+    expect(opts.exportBackground).toBe(false);
+    expect(opts.viewBackgroundColor).toBe('#000000');
+    expect(opts.exportWithDarkMode).toBe(true);
+    expect(opts.exportEmbedScene).toBe(true);
+    expect(opts.exportPadding).toBe(20);
+    expect(opts.exportScale).toBe(2);
+  });
+});

--- a/tests/unit/exporter/export-options.test.ts
+++ b/tests/unit/exporter/export-options.test.ts
@@ -23,7 +23,7 @@ describe('DEFAULT_EXPORT_OPTIONS', () => {
   });
 
   it('should have dark mode disabled by default', () => {
-    expect(DEFAULT_EXPORT_OPTIONS.exportWithDarkMode).toBe(false);
+    expect(DEFAULT_EXPORT_OPTIONS.dark).toBe(false);
   });
 
   it('should have embed scene disabled by default', () => {
@@ -35,7 +35,7 @@ describe('DEFAULT_EXPORT_OPTIONS', () => {
   });
 
   it('should have scale 1 by default', () => {
-    expect(DEFAULT_EXPORT_OPTIONS.exportScale).toBe(1);
+    expect(DEFAULT_EXPORT_OPTIONS.scale).toBe(1);
   });
 
   it('should have all required properties', () => {
@@ -44,10 +44,10 @@ describe('DEFAULT_EXPORT_OPTIONS', () => {
       'format',
       'exportBackground',
       'viewBackgroundColor',
-      'exportWithDarkMode',
+      'dark',
       'exportEmbedScene',
       'exportPadding',
-      'exportScale',
+      'scale',
     ];
     for (const key of keys) {
       expect(DEFAULT_EXPORT_OPTIONS[key]).toBeDefined();
@@ -72,17 +72,17 @@ describe('ExportOptions type', () => {
       format: 'png',
       exportBackground: false,
       viewBackgroundColor: '#000000',
-      exportWithDarkMode: true,
+      dark: true,
       exportEmbedScene: true,
       exportPadding: 20,
-      exportScale: 2,
+      scale: 2,
     };
     expect(opts.format).toBe('png');
     expect(opts.exportBackground).toBe(false);
     expect(opts.viewBackgroundColor).toBe('#000000');
-    expect(opts.exportWithDarkMode).toBe(true);
+    expect(opts.dark).toBe(true);
     expect(opts.exportEmbedScene).toBe(true);
     expect(opts.exportPadding).toBe(20);
-    expect(opts.exportScale).toBe(2);
+    expect(opts.scale).toBe(2);
   });
 });

--- a/tests/unit/exporter/swap-extension.test.ts
+++ b/tests/unit/exporter/swap-extension.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Unit tests for the {@link swapExtension} utility.
+ *
+ * Covers basic swaps, paths with directories, filenames with multiple dots,
+ * dotfiles, and various target extensions.
+ */
+
 import { describe, it, expect } from 'vitest';
 import { swapExtension } from '../../../src/exporter/image-exporter.js';
 

--- a/tests/unit/exporter/swap-extension.test.ts
+++ b/tests/unit/exporter/swap-extension.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { swapExtension } from '../../../src/exporter/image-exporter.js';
+
+describe('swapExtension', () => {
+  describe('basic extension swapping', () => {
+    it('should swap .excalidraw to .svg', () => {
+      expect(swapExtension('flowchart.excalidraw', 'svg')).toBe('flowchart.svg');
+    });
+
+    it('should swap .excalidraw to .png', () => {
+      expect(swapExtension('flowchart.excalidraw', 'png')).toBe('flowchart.png');
+    });
+
+    it('should swap .json to .svg', () => {
+      expect(swapExtension('diagram.json', 'svg')).toBe('diagram.svg');
+    });
+
+    it('should swap .txt to .png', () => {
+      expect(swapExtension('notes.txt', 'png')).toBe('notes.png');
+    });
+  });
+
+  describe('paths with directories', () => {
+    it('should handle relative paths', () => {
+      expect(swapExtension('./output/diagram.excalidraw', 'svg')).toBe('./output/diagram.svg');
+    });
+
+    it('should handle absolute paths', () => {
+      expect(swapExtension('/home/user/docs/chart.excalidraw', 'png')).toBe(
+        '/home/user/docs/chart.png'
+      );
+    });
+
+    it('should handle nested directory paths', () => {
+      expect(swapExtension('a/b/c/d.excalidraw', 'svg')).toBe('a/b/c/d.svg');
+    });
+  });
+
+  describe('edge cases with dots', () => {
+    it('should handle filenames with multiple dots', () => {
+      // swaps from last dot
+      expect(swapExtension('my.flow.chart.excalidraw', 'svg')).toBe('my.flow.chart.svg');
+    });
+
+    it('should handle directories with dots in names', () => {
+      expect(swapExtension('./v1.2/output.excalidraw', 'png')).toBe('./v1.2/output.png');
+    });
+
+    it('should handle filenames with no extension', () => {
+      // lastDot is -1, base = filePath
+      expect(swapExtension('noextension', 'svg')).toBe('noextension.svg');
+    });
+
+    it('should handle dotfiles (dot at position 0)', () => {
+      // lastDot is 0, condition `lastDot > 0` is false, so base = filePath
+      expect(swapExtension('.gitignore', 'svg')).toBe('.gitignore.svg');
+    });
+  });
+
+  describe('various new extensions', () => {
+    it('should work with longer extensions', () => {
+      expect(swapExtension('file.excalidraw', 'webp')).toBe('file.webp');
+    });
+
+    it('should work with uppercase extensions', () => {
+      expect(swapExtension('file.excalidraw', 'PNG')).toBe('file.PNG');
+    });
+
+    it('should handle empty-string extension', () => {
+      expect(swapExtension('file.excalidraw', '')).toBe('file.');
+    });
+  });
+});


### PR DESCRIPTION
This pull request introduces a new image export feature to the CLI, allowing users to convert `.excalidraw` files to PNG or SVG, and updates the documentation and dependencies to support this. The implementation includes a robust Node.js DOM polyfill to enable server-side SVG rendering with bundled fonts, and pins the `@excalidraw/utils` dependency to a specific prerelease version for stability.

**New image export functionality:**

- Added a new `convert` command to the CLI, enabling conversion of `.excalidraw` files to PNG or SVG with options for background, scale, padding, dark mode, and more.
- Exposed new programmatic APIs: `convertToSVG` and `convertToPNG` for direct usage in Node.js projects. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L150-R197) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R214-R234)

**Node.js DOM polyfill for SVG export:**

- Implemented `src/exporter/dom-polyfill.ts`, which sets up a minimal browser-like environment using `jsdom`, stubs for `Path2D`, and polyfills for `FontFace` and `document.fonts`, allowing `@excalidraw/utils` to render SVGs and load bundled fonts in Node.js.

**Dependency and compatibility updates:**

- Pinned `@excalidraw/utils` to `0.1.3-test32` (the only version with required export and font features) and documented the rationale and upgrade strategy in `DEPENDENCIES.md`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L37-R49) [[2]](diffhunk://#diff-73c2e4c2e886ff07d524b16ddbb70357b31daa755a7fa800fa8dc41140f7544eR1-R50)
- Updated `package.json` to require Node.js 20+ and added new dependencies: `jsdom`, `@resvg/resvg-js`, and their types.

**Documentation improvements:**

- Expanded `README.md` with detailed usage examples for the new `convert` command, programmatic export APIs, and clarified Node.js version requirements and dependency pinning. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R23-R37) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R75-R87) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L106-R154) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L150-R197) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R214-R234) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R256-R260)

**Minor CLI and documentation tweaks:**

- Added DOT file support to the `create` command input format options.

These changes collectively enable robust, server-side image export from Excalidraw files, with clear documentation and a stable dependency base.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export-to-image: SVG and PNG output with options for background, dark mode, padding, scale, and embedding scene data.
  * CLI convert command to export .excalidraw files to SVG/PNG.

* **Documentation**
  * Expanded README with export workflow, CLI reference, and API examples.

* **Chores**
  * Added ignore rule for temporary test files and updated dependencies to support image export.

* **Tests**
  * Added comprehensive unit and integration tests covering exporter and CLI scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->