### PR TITLE
Raise CI/publish Node baseline to 20.19.0 and enforce lint failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x]
+        node-version: ['20.19.0', 22.x]
 
     steps:
       - name: Checkout repository
@@ -49,11 +49,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: '20.19.0'
           cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
 
       - name: Run linter
-        run: npm run lint || true  # Don't fail on lint warnings for now
+        run: npm run lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: '20.19.0'
           cache: 'npm'
 
       - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: '20.19.0'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Breaking Changes
 
-- Raise the minimum supported Node.js version from Node 18 to `>=20.19.0`.
-- Ship the image exporter Node support change as the next major release.
+- Drop Node 18 support and raise the minimum supported Node.js version to `>=20.19.0`.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@
 
 ## Installation
 
-Requires `Node >=20.19.0`.
-
-This exporter change drops Node 18 support and should be released as the next major version.
+Requires `Node >=20.19.0`. Node 18 is no longer supported.
 
 ### Using npm
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,7 @@ export default [
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-explicit-any': 'warn',
+      'no-undef': 'off',
       'no-unused-vars': 'off',
     },
   },


### PR DESCRIPTION
## Summary
- Update GitHub Actions Node versions to use `20.19.0` as the minimum baseline (and keep `22.x` in CI matrix).
- Enforce linting in CI by removing the `|| true` fallback so lint errors fail the job.
- Align docs/changelog messaging to clearly state Node 18 is no longer supported and minimum is `>=20.19.0`.
- Adjust ESLint config by disabling `no-undef` to match current linting behavior.

## Testing
- Not run (content prepared from provided commit and diff).
- CI configuration check: verify `.github/workflows/ci.yml` runs test matrix on `20.19.0` and `22.x`.
- Lint gate check: verify CI fails when `npm run lint` reports errors.
- Publish workflow check: verify `.github/workflows/publish.yml` uses `20.19.0` for build/publish jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Node.js 18.x support removed. Minimum required version is now Node.js >=20.19.0.

* **Documentation**
  * Updated installation documentation and project changelog to reflect new Node.js version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->