### PR TITLE
Fix embedded images in PNG export

### DIFF
--- a/src/exporter/image-exporter.ts
+++ b/src/exporter/image-exporter.ts
@@ -10,6 +10,7 @@
  */
 
 import { parse, format } from 'node:path';
+import { JSDOM } from 'jsdom';
 import { withDOMPolyfill, getExcalidrawAssetDir } from './dom-polyfill.js';
 import type { ExcalidrawFile } from '../types/excalidraw.js';
 
@@ -131,9 +132,10 @@ export async function convertToPNG(
   const opts = resolveOptions(file, { format: 'png', ...options });
   return withExporterRuntime(async () => {
     const svgString = await renderSvg(file, opts);
+    const normalizedSvg = normalizeSvgForRasterization(svgString);
     const { Resvg } = await import('@resvg/resvg-js');
 
-    const widthMatch = svgString.match(/width="([^"]+)"/);
+    const widthMatch = normalizedSvg.match(/width="([^"]+)"/);
     const naturalWidth = widthMatch ? parseFloat(widthMatch[1]) : 800;
 
     const scale =
@@ -147,7 +149,7 @@ export async function convertToPNG(
     // still need the packaged Excalidraw font files to keep text rendering sane.
     const fontDir = getExcalidrawFontDir();
 
-    const resvg = new Resvg(svgString, {
+    const resvg = new Resvg(normalizedSvg, {
       fitTo: {
         mode: 'width' as const,
         value: scaledWidth,
@@ -164,6 +166,106 @@ export async function convertToPNG(
 
     return Buffer.from(pngBuffer);
   });
+}
+
+/**
+ * Normalize SVG output for rasterizers that do not fully support Excalidraw's
+ * image `<symbol>` + `<use>` pattern. We only apply this to the PNG path so
+ * raw SVG export stays identical to Excalidraw's browser-oriented markup.
+ */
+export function normalizeSvgForRasterization(svgString: string): string {
+  const dom = new JSDOM(svgString, { contentType: 'image/svg+xml' });
+  const doc = dom.window.document as any;
+  const root = doc.documentElement as any;
+
+  if (!root || root.nodeName.toLowerCase() !== 'svg') {
+    dom.window.close();
+    return svgString;
+  }
+
+  const imageSymbols = new Map<string, any>();
+
+  for (const symbol of Array.from(doc.querySelectorAll('symbol[id]')) as any[]) {
+    const id = symbol.getAttribute('id');
+    const image = Array.from(symbol.children).find(
+      (child: any) => child.tagName.toLowerCase() === 'image'
+    );
+    if (id && image) {
+      imageSymbols.set(id, image);
+    }
+  }
+
+  if (imageSymbols.size === 0) {
+    dom.window.close();
+    return svgString;
+  }
+
+  const touchedSymbolIds = new Set<string>();
+  const passthroughAttributes = [
+    'x',
+    'y',
+    'width',
+    'height',
+    'opacity',
+    'transform',
+    'style',
+    'class',
+    'clip-path',
+    'mask',
+    'filter',
+    'preserveAspectRatio',
+  ];
+
+  for (const useEl of Array.from(doc.querySelectorAll('use')) as any[]) {
+    const href = useEl.getAttribute('href') || useEl.getAttribute('xlink:href');
+    if (!href?.startsWith('#')) {
+      continue;
+    }
+
+    const image = imageSymbols.get(href.slice(1));
+    if (!image) {
+      continue;
+    }
+
+    const replacement = image.cloneNode(true) as any;
+    for (const attr of passthroughAttributes) {
+      const value = useEl.getAttribute(attr);
+      if (value !== null) {
+        replacement.setAttribute(attr, value);
+      }
+    }
+
+    useEl.replaceWith(replacement);
+    touchedSymbolIds.add(href.slice(1));
+  }
+
+  for (const symbolId of touchedSymbolIds) {
+    const stillReferenced = (Array.from(doc.querySelectorAll('use')) as any[]).some((useEl) => {
+      const href = useEl.getAttribute('href') || useEl.getAttribute('xlink:href');
+      return href === `#${symbolId}`;
+    });
+
+    if (stillReferenced) {
+      continue;
+    }
+
+    const symbol = (Array.from(doc.querySelectorAll('symbol[id]')) as any[]).find(
+      (candidate) => candidate.getAttribute('id') === symbolId
+    );
+    if (
+      symbol?.parentElement?.childElementCount === 1 &&
+      symbol.parentElement.tagName.toLowerCase() === 'defs'
+    ) {
+      symbol.parentElement.remove();
+      continue;
+    }
+
+    symbol?.remove();
+  }
+
+  const normalized = root.outerHTML;
+  dom.window.close();
+  return normalized;
 }
 
 /**

--- a/tests/fixtures/embedded-image.excalidraw
+++ b/tests/fixtures/embedded-image.excalidraw
@@ -1,0 +1,56 @@
+{
+  "type": "excalidraw",
+  "version": 2,
+  "source": "test",
+  "elements": [
+    {
+      "id": "img-1",
+      "type": "image",
+      "x": 10,
+      "y": 20,
+      "width": 32,
+      "height": 32,
+      "angle": 0,
+      "strokeColor": "#1e1e1e",
+      "backgroundColor": "transparent",
+      "fillStyle": "solid",
+      "strokeWidth": 2,
+      "strokeStyle": "solid",
+      "roughness": 1,
+      "opacity": 100,
+      "groupIds": [],
+      "frameId": null,
+      "index": "a0",
+      "roundness": null,
+      "seed": 1,
+      "version": 1,
+      "versionNonce": 1,
+      "isDeleted": false,
+      "boundElements": null,
+      "updated": 1,
+      "link": null,
+      "locked": false,
+      "fileId": "file-1",
+      "status": "saved",
+      "scale": [
+        1,
+        1
+      ]
+    }
+  ],
+  "appState": {
+    "gridSize": 20,
+    "gridStep": 5,
+    "gridModeEnabled": false,
+    "viewBackgroundColor": "#ffffff",
+    "lockedMultiSelections": {}
+  },
+  "files": {
+    "file-1": {
+      "mimeType": "image/png",
+      "id": "file-1",
+      "dataURL": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAQAAAAECAYAAACp8Z5+AAAAEUlEQVR4nGP8z8AARAhAhgAAP70H/ZMggSAAAAAASUVORK5CYII=",
+      "created": 1
+    }
+  }
+}

--- a/tests/helpers/fixtures.ts
+++ b/tests/helpers/fixtures.ts
@@ -3,7 +3,13 @@
  * Provides minimal valid ExcalidrawFile fixtures.
  */
 
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import type { ExcalidrawFile } from '../../src/types/excalidraw.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEST_ROOT = join(__dirname, '..');
 
 /**
  * Create a minimal ExcalidrawFile with a single rectangle element.
@@ -247,4 +253,12 @@ export function createFileWithBackground(color: string): ExcalidrawFile {
   const file = createMinimalFile();
   file.appState.viewBackgroundColor = color;
   return file;
+}
+
+/**
+ * Load an Excalidraw fixture from the tests/fixtures directory.
+ */
+export function loadExcalidrawFixture(name: string): ExcalidrawFile {
+  const filePath = join(TEST_ROOT, 'fixtures', name);
+  return JSON.parse(readFileSync(filePath, 'utf-8')) as ExcalidrawFile;
 }

--- a/tests/integration/exporter/png-export.test.ts
+++ b/tests/integration/exporter/png-export.test.ts
@@ -6,15 +6,118 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import { inflateSync } from 'zlib';
 import { convertToPNG, convertImage } from '../../../src/exporter/image-exporter.js';
 import {
   createMinimalFile,
   createMultiElementFile,
   createFileWithBackground,
+  loadExcalidrawFixture,
 } from '../../helpers/fixtures.js';
 
 // PNG magic bytes: 0x89 0x50 0x4E 0x47 (‰PNG)
 const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+
+function paethPredictor(a: number, b: number, c: number): number {
+  const p = a + b - c;
+  const pa = Math.abs(p - a);
+  const pb = Math.abs(p - b);
+  const pc = Math.abs(p - c);
+
+  if (pa <= pb && pa <= pc) return a;
+  if (pb <= pc) return b;
+  return c;
+}
+
+function decodePngRgba(png: Buffer): { width: number; height: number; pixels: Buffer } {
+  const signature = png.subarray(0, 8);
+  expect(signature.equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))).toBe(true);
+
+  let offset = 8;
+  let width = 0;
+  let height = 0;
+  let bitDepth = 0;
+  let colorType = 0;
+  const idatChunks: Buffer[] = [];
+
+  while (offset < png.length) {
+    const length = png.readUInt32BE(offset);
+    const type = png.toString('ascii', offset + 4, offset + 8);
+    const dataStart = offset + 8;
+    const dataEnd = dataStart + length;
+    const data = png.subarray(dataStart, dataEnd);
+    offset = dataEnd + 4;
+
+    if (type === 'IHDR') {
+      width = data.readUInt32BE(0);
+      height = data.readUInt32BE(4);
+      bitDepth = data[8];
+      colorType = data[9];
+    } else if (type === 'IDAT') {
+      idatChunks.push(data);
+    } else if (type === 'IEND') {
+      break;
+    }
+  }
+
+  expect(bitDepth).toBe(8);
+  expect(colorType).toBe(6);
+
+  const raw = inflateSync(Buffer.concat(idatChunks));
+  const stride = width * 4;
+  const pixels = Buffer.alloc(width * height * 4);
+  let src = 0;
+
+  for (let y = 0; y < height; y++) {
+    const filter = raw[src++];
+    const rowStart = y * stride;
+
+    for (let x = 0; x < stride; x++) {
+      const byte = raw[src++];
+      const left = x >= 4 ? pixels[rowStart + x - 4] : 0;
+      const up = y > 0 ? pixels[rowStart - stride + x] : 0;
+      const upLeft = y > 0 && x >= 4 ? pixels[rowStart - stride + x - 4] : 0;
+
+      let value = byte;
+      switch (filter) {
+        case 0:
+          break;
+        case 1:
+          value = (byte + left) & 0xff;
+          break;
+        case 2:
+          value = (byte + up) & 0xff;
+          break;
+        case 3:
+          value = (byte + Math.floor((left + up) / 2)) & 0xff;
+          break;
+        case 4:
+          value = (byte + paethPredictor(left, up, upLeft)) & 0xff;
+          break;
+        default:
+          throw new Error(`Unsupported PNG filter type: ${filter}`);
+      }
+
+      pixels[rowStart + x] = value;
+    }
+  }
+
+  return { width, height, pixels };
+}
+
+function getPixel(
+  decoded: { width: number; height: number; pixels: Buffer },
+  x: number,
+  y: number
+): [number, number, number, number] {
+  const index = (y * decoded.width + x) * 4;
+  return [
+    decoded.pixels[index],
+    decoded.pixels[index + 1],
+    decoded.pixels[index + 2],
+    decoded.pixels[index + 3],
+  ];
+}
 
 describe('convertToPNG', () => {
   describe('basic PNG generation', () => {
@@ -144,6 +247,30 @@ describe('convertToPNG', () => {
 
       expect(Buffer.isBuffer(png)).toBe(true);
       expect(png.subarray(0, 4).equals(PNG_MAGIC)).toBe(true);
+    }, 30000);
+  });
+
+  describe('embedded images', () => {
+    it('should render embedded image content instead of placeholder squares', async () => {
+      const file = loadExcalidrawFixture('embedded-image.excalidraw');
+      const png = await convertToPNG(file, { exportBackground: false, padding: 0 });
+      const decoded = decodePngRgba(png);
+
+      expect(decoded.width).toBeGreaterThanOrEqual(32);
+      expect(decoded.height).toBeGreaterThanOrEqual(32);
+
+      let sawRedPixel = false;
+      for (let y = 0; y < decoded.height && !sawRedPixel; y++) {
+        for (let x = 0; x < decoded.width; x++) {
+          const [r, g, b, a] = getPixel(decoded, x, y);
+          if (r > 200 && g < 80 && b < 80 && a > 200) {
+            sawRedPixel = true;
+            break;
+          }
+        }
+      }
+
+      expect(sawRedPixel).toBe(true);
     }, 30000);
   });
 });

--- a/tests/unit/exporter/svg-normalizer.test.ts
+++ b/tests/unit/exporter/svg-normalizer.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeSvgForRasterization } from '../../../src/exporter/image-exporter.js';
+
+describe('normalizeSvgForRasterization', () => {
+  it('inlines image symbol use nodes for rasterizers', () => {
+    const svg = [
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">',
+      '  <defs>',
+      '    <symbol id="image-file-1">',
+      '      <image href="data:image/png;base64,abc" preserveAspectRatio="none" width="100%" height="100%"></image>',
+      '    </symbol>',
+      '    <clipPath id="clip-1"><rect width="16" height="16"></rect></clipPath>',
+      '  </defs>',
+      '  <g transform="translate(10 20)">',
+      '    <use href="#image-file-1" width="24" height="18" opacity="0.5" transform="scale(2)" clip-path="url(#clip-1)"></use>',
+      '  </g>',
+      '</svg>',
+    ].join('');
+
+    const normalized = normalizeSvgForRasterization(svg);
+
+    expect(normalized).not.toContain('<use href="#image-file-1"');
+    expect(normalized).toContain('<image');
+    expect(normalized).toContain('href="data:image/png;base64,abc"');
+    expect(normalized).toContain('width="24"');
+    expect(normalized).toContain('height="18"');
+    expect(normalized).toContain('opacity="0.5"');
+    expect(normalized).toContain('transform="scale(2)"');
+    expect(normalized).toContain('clip-path="url(#clip-1)"');
+    expect(normalized).toContain('<clipPath id="clip-1">');
+    expect(normalized).not.toContain('<symbol id="image-file-1"');
+  });
+
+  it('leaves unrelated symbol references untouched', () => {
+    const svg = [
+      '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32">',
+      '  <defs>',
+      '    <symbol id="shape-symbol"><rect width="10" height="10"></rect></symbol>',
+      '  </defs>',
+      '  <use href="#shape-symbol" width="10" height="10"></use>',
+      '</svg>',
+    ].join('');
+
+    const normalized = normalizeSvgForRasterization(svg);
+
+    expect(normalized).toContain('<use href="#shape-symbol"');
+    expect(normalized).toContain('<symbol id="shape-symbol"');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a PNG-only SVG normalization step before `@resvg/resvg-js` rasterization
- inline Excalidraw image `<symbol>` / `<use>` references into direct `<image>` nodes for PNG export only
- add an embedded-image `.excalidraw` fixture plus regression coverage for normalization and PNG rendering

## Testing
- `npm run build`
- `npm run test:run -- tests/unit/exporter/svg-normalizer.test.ts tests/integration/exporter/png-export.test.ts`
- `npm run test:run -- tests/integration/exporter tests/unit/exporter`
- verified fixture behavior before/after with the embedded-image sample:
  - raw SVG export still contains `<symbol>` + `<use>`
  - normalized PNG path removes the `<use>` indirection and keeps direct `<image>` content

## Acceptance criteria
- `excalidraw-cli convert --format png` renders embedded images in `.excalidraw` files correctly
- PNG exports display the actual embedded image content instead of black/white placeholder boxes
- SVG export behavior remains unchanged
- regression coverage exists for embedded-image PNG export and SVG normalization
- fixes #23 

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-684da992-fef4-4867-9b81-ff75c6e89ced"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-684da992-fef4-4867-9b81-ff75c6e89ced"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved PNG export handling for documents with embedded images referenced via SVG symbol definitions, ensuring images export correctly instead of displaying as placeholders.

* **Tests**
  * Added comprehensive test coverage for embedded image export functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->