### PR TITLE
feat: support reverse and bidirectional arrows in DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ excalidraw-cli convert diagram.excalidraw --format svg --no-export-background
 | `(Label)` | Ellipse | Start/End points |
 | `[[Label]]` | Database | Data storage |
 | `[Label @fillStyle:hachure @backgroundColor:#a5d8ff]` | Styled node | Add inline node style attributes |
-| `->` | Arrow | Connection |
+| `->` | Arrow | Forward connection |
+| `<-` | Reverse Arrow | Reverse connection, logically parsed as right-to-left |
+| `<->` | Bidirectional Arrow | Connection with arrowheads on both ends |
 | `-->` | Dashed Arrow | Dashed connection |
 | `-> "text" ->` | Labeled Arrow | Connection with label |
 
@@ -102,6 +104,8 @@ excalidraw-cli convert diagram.excalidraw --format svg --no-export-background
 (Start) -> [Enter Credentials] -> {Valid?}
 {Valid?} -> "yes" -> [Dashboard] -> (End)
 {Valid?} -> "no" -> [Show Error] -> [Enter Credentials]
+[Reviewer] <- [Approved]
+[Client] <-> [API]
 ```
 
 ### Node Styling

--- a/src/factory/connection-factory.ts
+++ b/src/factory/connection-factory.ts
@@ -24,8 +24,8 @@ function mapEdgeStyle(style?: EdgeStyle): Partial<ExcalidrawArrow> {
   if (style.strokeWidth !== undefined) result.strokeWidth = style.strokeWidth;
   if (style.strokeStyle !== undefined) result.strokeStyle = style.strokeStyle;
   if (style.roughness !== undefined) result.roughness = style.roughness;
-  result.startArrowhead = style.startArrowhead ?? null;
-  result.endArrowhead = style.endArrowhead ?? 'arrow';
+  if (style.startArrowhead !== undefined) result.startArrowhead = style.startArrowhead;
+  if (style.endArrowhead !== undefined) result.endArrowhead = style.endArrowhead;
   return result;
 }
 
@@ -75,8 +75,8 @@ export function createArrow(
     lastCommittedPoint: null,
     startBinding: startBindingInfo.binding,
     endBinding: endBindingInfo.binding,
-    startArrowhead: styleProps.startArrowhead ?? null,
-    endArrowhead: styleProps.endArrowhead ?? 'arrow',
+    startArrowhead: styleProps.startArrowhead !== undefined ? styleProps.startArrowhead : null,
+    endArrowhead: styleProps.endArrowhead !== undefined ? styleProps.endArrowhead : 'arrow',
     elbowed: false,
   } as ExcalidrawArrow;
 }
@@ -120,8 +120,8 @@ export function createArrowWithBindings(
     lastCommittedPoint: null,
     startBinding,
     endBinding,
-    startArrowhead: styleProps.startArrowhead ?? null,
-    endArrowhead: styleProps.endArrowhead ?? 'arrow',
+    startArrowhead: styleProps.startArrowhead !== undefined ? styleProps.startArrowhead : null,
+    endArrowhead: styleProps.endArrowhead !== undefined ? styleProps.endArrowhead : 'arrow',
     elbowed: false,
   } as ExcalidrawArrow;
 }

--- a/src/parser/dsl-parser.ts
+++ b/src/parser/dsl-parser.ts
@@ -46,6 +46,8 @@ interface Token {
   nodeType?: NodeType;
   nodeStyle?: NodeStyle;
   dashed?: boolean;
+  reversed?: boolean;
+  bidirectional?: boolean;
   // Image-specific properties
   imageSrc?: string;
   imageWidth?: number;
@@ -441,6 +443,20 @@ function tokenize(input: string): Token[] {
       continue;
     }
 
+    // Bidirectional arrow <->
+    if (input[i] === '<' && input[i + 1] === '-' && input[i + 2] === '>') {
+      tokens.push({ type: 'arrow', value: '<->', bidirectional: true });
+      i += 3;
+      continue;
+    }
+
+    // Reverse arrow <-
+    if (input[i] === '<' && input[i + 1] === '-') {
+      tokens.push({ type: 'arrow', value: '<-', reversed: true });
+      i += 2;
+      continue;
+    }
+
     // Dashed arrow -->
     if (input[i] === '-' && input[i + 1] === '-' && input[i + 2] === '>') {
       tokens.push({ type: 'arrow', value: '-->', dashed: true });
@@ -592,6 +608,32 @@ export function parseDSL(input: string): FlowchartGraph {
   let lastNode: GraphNode | null = null;
   let pendingLabel: string | null = null;
   let pendingDashed = false;
+  let pendingReversed = false;
+  let pendingBidirectional = false;
+
+  function createPendingEdge(sourceNode: GraphNode, targetNode: GraphNode): void {
+    const style = {
+      ...(pendingDashed ? { strokeStyle: 'dashed' as const } : {}),
+      ...(pendingBidirectional
+        ? { startArrowhead: 'arrow' as const, endArrowhead: 'arrow' as const }
+        : pendingReversed
+          ? { startArrowhead: 'arrow' as const, endArrowhead: null }
+          : {}),
+    };
+
+    edges.push({
+      id: nanoid(10),
+      source: pendingReversed ? targetNode.id : sourceNode.id,
+      target: pendingReversed ? sourceNode.id : targetNode.id,
+      label: pendingLabel || undefined,
+      style: Object.keys(style).length > 0 ? style : undefined,
+    });
+
+    pendingLabel = null;
+    pendingDashed = false;
+    pendingReversed = false;
+    pendingBidirectional = false;
+  }
 
   while (i < tokens.length) {
     const token = tokens[i];
@@ -600,6 +642,8 @@ export function parseDSL(input: string): FlowchartGraph {
       lastNode = null;
       pendingLabel = null;
       pendingDashed = false;
+      pendingReversed = false;
+      pendingBidirectional = false;
       i++;
       continue;
     }
@@ -661,15 +705,7 @@ export function parseDSL(input: string): FlowchartGraph {
       const node = getOrCreateNode(token.value, 'image', imageData);
 
       if (lastNode) {
-        edges.push({
-          id: nanoid(10),
-          source: lastNode.id,
-          target: node.id,
-          label: pendingLabel || undefined,
-          style: pendingDashed ? { strokeStyle: 'dashed' } : undefined,
-        });
-        pendingLabel = null;
-        pendingDashed = false;
+        createPendingEdge(lastNode, node);
       }
 
       lastNode = node;
@@ -696,16 +732,7 @@ export function parseDSL(input: string): FlowchartGraph {
       const node = getOrCreateNode(token.value, token.nodeType!, undefined, token.nodeStyle);
 
       if (lastNode) {
-        // Create edge from lastNode to this node
-        edges.push({
-          id: nanoid(10),
-          source: lastNode.id,
-          target: node.id,
-          label: pendingLabel || undefined,
-          style: pendingDashed ? { strokeStyle: 'dashed' } : undefined,
-        });
-        pendingLabel = null;
-        pendingDashed = false;
+        createPendingEdge(lastNode, node);
       }
 
       lastNode = node;
@@ -715,6 +742,8 @@ export function parseDSL(input: string): FlowchartGraph {
 
     if (token.type === 'arrow') {
       pendingDashed = token.dashed || false;
+      pendingReversed = token.reversed || false;
+      pendingBidirectional = token.bidirectional || false;
       i++;
       continue;
     }

--- a/tests/integration/exporter/cli-export.test.ts
+++ b/tests/integration/exporter/cli-export.test.ts
@@ -120,6 +120,25 @@ describe('CLI export command', () => {
       expect(existsSync(autoSvg)).toBe(true);
     }, 60000);
 
+    it('should preserve reverse and bidirectional arrowheads through CLI create output', () => {
+      const outputFile = tmpFile('arrow-directions.excalidraw');
+
+      runCLI([
+        'create',
+        '--inline',
+        '[A] <- [B]\n[C] <-> [D]',
+        '-o',
+        outputFile,
+      ]);
+
+      const file = JSON.parse(readFileSync(outputFile, 'utf-8'));
+      const arrows = file.elements.filter((element: { type: string }) => element.type === 'arrow');
+
+      expect(arrows).toHaveLength(2);
+      expect(arrows[0]).toMatchObject({ startArrowhead: 'arrow', endArrowhead: null });
+      expect(arrows[1]).toMatchObject({ startArrowhead: 'arrow', endArrowhead: 'arrow' });
+    }, 60000);
+
     it('should export with --verbose flag', () => {
       const inputFile = tmpFile('verbose-test.excalidraw');
       writeFileSync(inputFile, JSON.stringify(createMinimalFile()), 'utf-8');

--- a/tests/unit/parser/dsl-parser.test.ts
+++ b/tests/unit/parser/dsl-parser.test.ts
@@ -65,6 +65,18 @@ describe('DSL Parser', () => {
       expect(result.nodes[0].label).toBe('email@company.com');
       expect(result.nodes[0].style).toBeUndefined();
     });
+
+    it('should generate Excalidraw arrows for reverse and bidirectional connections', async () => {
+      const graph = parseDSL(`[A] <- [B]
+[C] <-> [D]`);
+      const layouted = await layoutGraph(graph);
+      const file = generateExcalidraw(layouted);
+      const arrows = file.elements.filter((element) => element.type === 'arrow');
+
+      expect(arrows).toHaveLength(2);
+      expect(arrows[0]).toMatchObject({ startArrowhead: 'arrow', endArrowhead: null });
+      expect(arrows[1]).toMatchObject({ startArrowhead: 'arrow', endArrowhead: 'arrow' });
+    });
   });
 
   describe('connection parsing', () => {
@@ -84,6 +96,28 @@ describe('DSL Parser', () => {
     it('should parse dashed connections', () => {
       const result = parseDSL('[A] --> [B]');
       expect(result.edges[0].style?.strokeStyle).toBe('dashed');
+    });
+
+    it('should parse reverse connections as logical right-to-left edges', () => {
+      const result = parseDSL('[A] <- [B]');
+      expect(result.edges).toHaveLength(1);
+      expect(result.edges[0].source).toBe(result.nodes[1].id);
+      expect(result.edges[0].target).toBe(result.nodes[0].id);
+      expect(result.edges[0].style).toEqual({
+        startArrowhead: 'arrow',
+        endArrowhead: null,
+      });
+    });
+
+    it('should parse bidirectional connections with arrowheads on both ends', () => {
+      const result = parseDSL('[A] <-> [B]');
+      expect(result.edges).toHaveLength(1);
+      expect(result.edges[0].source).toBe(result.nodes[0].id);
+      expect(result.edges[0].target).toBe(result.nodes[1].id);
+      expect(result.edges[0].style).toEqual({
+        startArrowhead: 'arrow',
+        endArrowhead: 'arrow',
+      });
     });
 
     it('should parse chains of connections', () => {


### PR DESCRIPTION
## Summary
- add DSL parser support for `<-` and `<->`
- preserve logical graph direction for reverse arrows while rendering correct Excalidraw arrowheads
- cover parser, generator, and CLI output, and document the new syntax

## Testing
- npm run build
- npm run lint
- npm run test:run
- node dist/cli.js create --inline "[A] <- [B]
[C] <-> [D]" -o tests/tmp/manual/arrow-directions.excalidraw