### PR TITLE
Add AGENTS.md with Cursor Cloud specific instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single-package Node.js/TypeScript CLI tool (`excalidraw-cli`). No external services, databases, or Docker are required.
+
+### Key commands
+
+All standard commands are in `package.json` scripts:
+
+| Task | Command |
+|------|---------|
+| Install deps | `npm install` |
+| Build | `npm run build` |
+| Dev (watch) | `npm run dev` |
+| Lint | `npm run lint` |
+| Test (watch) | `npm test` |
+| Test (single run) | `npm run test:run` |
+| Format | `npm run format` |
+
+### Notes
+
+- The project is ESM (`"type": "module"`). Always use ESM imports in source and tests.
+- `npm run build` compiles `src/` to `dist/` via `tsc`. The CLI entry point is `dist/cli.js`.
+- Lint produces `@typescript-eslint/no-explicit-any` warnings in `src/exporter/image-exporter.ts`; these are pre-existing and expected.
+- Tests use Vitest. All test files are in `tests/` and follow the pattern `tests/**/*.test.ts`.
+- To run the CLI locally after building: `node dist/cli.js <command>`.
+- Node.js >= 20.19.0 is required (see `engines` in `package.json`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

Includes a concise reference of key commands (build, lint, test, dev) and non-obvious caveats (ESM module system, pre-existing lint warnings, Node version requirement).

**Environment verification:**

All checks pass on the current `main` branch:
- `npm run build` — clean compile
- `npm run lint` — 0 errors (9 pre-existing `no-explicit-any` warnings)
- `npm run test:run` — 171/171 tests pass
- CLI hello-world: created diagram and exported to PNG/SVG

[Hello world diagram exported to PNG](https://cursor.com/agents/bc-48ca10dd-7fe5-41a7-b708-ba98df6bab76/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_diagram.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48ca10dd-7fe5-41a7-b708-ba98df6bab76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48ca10dd-7fe5-41a7-b708-ba98df6bab76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

